### PR TITLE
Added output of soil layer properties at the end of the simulation

### DIFF
--- a/src/hru_output.f90
+++ b/src/hru_output.f90
@@ -274,20 +274,9 @@
              hpw_a(j) = hpwz
          end if
          
-         !! write yearly crop yields
-         if (time%end_yr == 1) then
-           if (pco%crop_yld == "y" .or. pco%crop_yld == "b") then
-             do ipl = 1, pcom(j)%npl
-               if (pcom(j)%plcur(ipl)%harv_num_yr > 0) then 
-                 pl_mass(j)%yield_yr(ipl) = pl_mass(j)%yield_yr(ipl) / float(pcom(j)%plcur(ipl)%harv_num_yr)
-               endif
-               write (4010,103) time%day, time%mo, time%day_mo, time%yrc, j, pcom(j)%pl(ipl), pl_mass(j)%yield_yr(ipl)
-               if (pco%csvout == "y") then
-                 write (4011,'(*(G0.3,:","))') time%day, time%mo, time%day_mo, time%yrc, j, pcom(j)%pl(ipl), pl_mass(j)%yield_yr(ipl) 
-               end if
-             end do 
-           end if
-         end if
+         if (time%end_sim == 1 .and. pco%cb_hru%a == "y") then
+          call soil_nutcarb_write(" a")    
+         endif
 
          !! write average annual crop yields
          if (time%end_sim == 1) then

--- a/src/output_landscape_init.f90
+++ b/src/output_landscape_init.f90
@@ -641,6 +641,21 @@
           endif
         endif
 
+        !! write end of simulation soil properties headers to hru_endsim_soil_prop
+        if (bsn_cc%cswat == 2) then
+          if (pco%cb_hru%a == "y") then
+            open (4584,file = "hru_endsim_soil_prop.txt", recl = 1500)
+            write (4584,*)  bsn%name, prog
+            write (4584,*)  endsim_soil_prop_hdr
+            write (9000,*) "HRU                       hru_endsim_soil_prop.txt"
+            if (pco%csvout == "y") then
+              open (4585,file="hru_endsim_soil_prop.csv", recl = 1500)
+              write (4585,*)  bsn%name, prog
+              write (4585,'(*(G0.3,:,","))') endsim_soil_prop_hdr
+              write (9000,*) "HRU                       hru_endsim_soil_prop.csv"
+            end if
+          endif
+        endif
         
  !! NEW BASIN CARBON ALL OUTPUT FILE
         

--- a/src/output_landscape_module.f90
+++ b/src/output_landscape_module.f90
@@ -782,7 +782,7 @@
 !! NEW PLANT CARBON STAT OUTPUT
       
      type output_plc_header     
-         character (len=6) ::  freq          =    "freq  "
+         character (len=7) ::  freq          =    "freq   "
          character (len=11) :: day           =    "       jday"
          character (len=11) :: mo            =    "        mon"
          character (len=11) :: day_mo        =    "        day"
@@ -800,7 +800,7 @@
       type (output_plc_header) :: plc_hdr
       
       type output_plc_header_units      
-         character (len=6) ::  freq         =    "      "
+         character (len=7) ::  freq         =    "       "
          character (len=11) :: day          =    "           "
          character (len=11) :: mo           =    "           "
          character (len=11) :: day_mo       =    "           "
@@ -822,7 +822,7 @@
 !! NEW RESIDUE CARBON STAT OUTPUT
       
      type output_rsdc_header     
-         character (len=6) ::  freq          =    "freq  "
+         character (len=7) ::  freq          =    "freq   "
          character (len=12) :: soil_lyr      =    "    soil_lyr"
          character (len=12) :: soil_depth    =    "  soil_depth"
          character (len=12) :: day           =    "        jday"
@@ -844,7 +844,7 @@
       type (output_rsdc_header) :: rsdc_hdr
       
       type output_rsdc_header_units      
-         character (len=6) ::  freq         =  "      "
+         character (len=7) ::  freq         =  "       "
          character (len=12) :: soil_lyr     =  "            "
          character (len=12) :: soil_depth   =  "          mm"
          character (len=12) :: day          =  "            "
@@ -870,7 +870,7 @@
 !! NEW SOIL CARBON STAT OUTPUT
       
      type output_soilc_header     
-         character (len=6) ::  freq          =    "freq  "
+         character (len=7) ::  freq          =    "freq   "
          character (len=12) :: soil_lyr      =    "    soil_lyr"
          character (len=12) :: soil_depth    =    "  soil_depth"
          character (len=12) :: day           =    "        jday"
@@ -892,7 +892,7 @@
       type (output_soilc_header) :: soilc_hdr
       
       type output_soilc_header_units      
-         character (len=6) ::  freq         = "      "
+         character (len=7) ::  freq         = "       "
          character (len=12) :: soil_lyr     = "            "
          character (len=12) :: soil_depth   = "          mm"
          character (len=12) :: day          = "            "
@@ -914,7 +914,7 @@
       type (output_soilc_header_units) :: soilc_hdr_units
 
      type output_soil_org_flux_header     
-         character (len=6) ::  freq          =    "freq  "
+         character (len=7) ::  freq          =    "freq   "
          character (len=12) :: soil_lyr      =    "    soil_lyr"
          character (len=12) :: soil_depth    =    "  soil_depth"
          character (len=12) :: day           =    "        jday"
@@ -965,7 +965,7 @@
       type (output_soil_org_flux_header) :: soil_org_flux_hdr
 
      type output_soil_org_flux_header_units     
-         character (len=6)  :: freq         = "      "
+         character (len=7)  :: freq         = "       "
          character (len=12) :: soil_lyr     = "            "
          character (len=12) :: soil_depth   = "          mm"
          character (len=12) :: day          = "            "
@@ -1008,8 +1008,6 @@
          character(len=15)  :: mnrs1s3   =    "        kg_N/ha" 
          character(len=15)  :: mnrs2s1   =    "        kg_N/ha" 
          character(len=15)  :: mnrs2s3   =    "        kg_N/ha" 
-         character(len=15)  :: mnrs3s1   =    "        kg_N/ha" 
-         character(len=15)  :: co2fs1    =    "        kg_C/ha" 
          character(len=15)  :: co2fs2    =    "        kg_C/ha"  
          character(len=15)  :: co2fs3    =    "        kg_C/ha" 
          end type output_soil_org_flux_header_units
@@ -1017,7 +1015,7 @@
       
       ! output soil_carb_mb_stat header
       type output_soil_carb_mb_hdr     
-         character (len=6) ::  freq          =    "freq  "
+         character (len=7) ::  freq          =    "freq   "
          character (len=12) :: soil_lyr      =    "    soil_lyr"
          character (len=12) :: soil_depth    =    "  soil_depth"
          character (len=12) :: day           =    "        jday"
@@ -1076,7 +1074,7 @@
       type (output_soil_carb_mb_hdr) :: soil_mb_hdr
       
       type output_soil_carb_mb_units
-         character (len=6)  :: freq         = "      "
+         character (len=7)  :: freq         = "       "
          character (len=12) :: soil_lyr     = "            "
          character (len=12) :: soil_depth   = "          mm"
          character (len=12) :: day          = "            "
@@ -1135,7 +1133,7 @@
       type (output_soil_carb_mb_units) :: soil_mb_units
 
      type output_cpool_header     
-         character (len=6) ::  freq          =    "freq  "
+         character (len=7) ::  freq          =    "freq   "
          character (len=12) :: soil_lyr      =    "    soil_lyr"
          character (len=12) :: soil_depth    =    "  soil_depth"
          character (len=12) :: day           =    "        jday"
@@ -1158,7 +1156,7 @@
       type (output_cpool_header) :: cpool_hdr
       
       type output_cpool_header_units      
-         character (len=6) ::  freq         =  "      "
+         character (len=7) ::  freq         =  "       "
          character (len=12) :: soil_lyr     =  "            "
          character (len=12) :: soil_depth   =  "          mm"
          character (len=12) :: day          =  "            "
@@ -1181,7 +1179,7 @@
       type (output_cpool_header_units) :: cpool_units
 
      type output_n_p_pool_header     
-         character (len=6) ::  freq          =    "freq  "
+         character (len=7) ::  freq          =    "freq   "
          character (len=12) :: soil_lyr      =    "    soil_lyr"
          character (len=12) :: soil_depth    =    "  soil_depth"
          character (len=12) :: day           =    "        jday"
@@ -1215,7 +1213,7 @@
       type (output_n_p_pool_header) :: n_p_pool_hdr
       
       type output_n_p_pool_header_units      
-         character (len=6) ::  freq         =  "      "
+         character (len=7) ::  freq         =  "       "
          character (len=12) :: soil_lyr     =  "            "
          character (len=12) :: soil_depth   =  "          mm"
          character (len=12) :: day          =  "            "
@@ -1249,7 +1247,7 @@
       type (output_n_p_pool_header_units) :: n_p_pool_units
 
      type output_carb_vars_header     
-         character (len=6) ::  freq          =    "freq  "
+         character (len=7) ::  freq          =    "freq   "
          character (len=12) :: soil_lyr      =    "    soil_lyr"
          character (len=12) :: soil_depth    =    "  soil_depth"
          character (len=12) :: day           =    "        jday"
@@ -1272,7 +1270,7 @@
       type (output_carb_vars_header) :: carbvars_hdr
       
      type output_org_allo_header     
-         character (len=6) ::  freq          =    "freq  "
+         character (len=7) ::  freq          =    "freq   "
          character (len=12) :: soil_lyr      =    "    soil_lyr"
          character (len=12) :: soil_depth    =    "  soil_depth"
          character (len=12) :: day           =    "        jday"
@@ -1292,7 +1290,7 @@
       type (output_org_allo_header) :: org_allow_hdr
       
      type output_org_ratio_header     
-         character (len=6) ::  freq          =    "freq  "
+         character (len=7) ::  freq          =    "freq   "
          character (len=12) :: soil_lyr      =    "    soil_lyr"
          character (len=12) :: soil_depth    =    "  soil_depth"
          character (len=12) :: day           =    "        jday"
@@ -1309,7 +1307,7 @@
       type (output_org_ratio_header) :: org_ratio_hdr
       
      type output_org_trans_header     
-         character (len=6) ::  freq          =    "freq  "
+         character (len=7) ::  freq          =    "freq   "
          character (len=12) :: soil_lyr      =    "    soil_lyr"
          character (len=12) :: soil_depth    =    "  soil_depth"
          character (len=12) :: day           =    "        jday"
@@ -1335,7 +1333,7 @@
       type (output_org_trans_header) :: org_trans_hdr
       
       type output_org_trans_header_units      
-         character (len=6) ::  freq         =  "      "
+         character (len=7) ::  freq         =  "       "
          character (len=12) :: soil_lyr     =  "            "
          character (len=12) :: soil_depth   =  "          mm"
          character (len=12) :: day          =  "            "
@@ -1359,6 +1357,35 @@
          character(len=15)  :: lsntp        =  "          kg/ha"  
         end type output_org_trans_header_units
       type (output_org_trans_header_units) :: org_trans_units
+
+     type output_endsim_soil_prop_header     
+         character (len=7)  :: freq          =    "freq   "
+         character (len=20) :: soil_name     =    "soil_name           "
+         character (len=8)  :: soil_lyr      =    "soil_lyr"
+         character (len=12) :: soil_depth    =    "  soil_depth"
+         character (len=12) :: day           =    "        jday"
+         character (len=12) :: mo            =    "         mon"
+         character (len=12) :: day_mo        =    "         day"
+         character (len=12) :: yrc           =    "          yr"
+         character (len=12) :: isd           =    "        unit"
+         character (len=22) :: id            =    "                gis_id"
+         character (len=13) :: name          =    "    name     "  
+         character(len=15)  :: bd            =    "             bd"
+         character(len=15)  :: awc           =    "            awc"
+         character(len=15)  :: soil_k        =    "         soil_k"  
+         character(len=15)  :: carbon        =    "         carbon"         
+         character(len=15)  :: clay          =    "           clay"         
+         character(len=15)  :: silt          =    "           silt"         
+         character(len=15)  :: sand          =    "           sand"         
+         character(len=15)  :: rock          =    "           rock"         
+         character(len=15)  :: alb           =    "            alb"         
+         character(len=15)  :: usle_k        =    "         usle_k"         
+         character(len=15)  :: ec            =    "             ec"      
+         character(len=15)  :: caco3         =    "          caco3"
+         character(len=15)  :: ph            =    "             ph"  
+         end type output_endsim_soil_prop_header
+      type (output_endsim_soil_prop_header) ::endsim_soil_prop_hdr
+      
 
 
 !!! NEW SOIL CARBON STAT OUTPUT

--- a/src/soil_nutcarb_write.f90
+++ b/src/soil_nutcarb_write.f90
@@ -335,7 +335,7 @@
           if (pco%csvout == "y") then
             do ly = 1, soil(j)%nly
               write (4585,'(*(G0.7,:,","))') freq_label, soil(j)%snam, ly, int(soil(j)%phys(ly)%d), time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, &
-                          soil(j)%phys(ly)%bd, soil(j)%phys(ly)%awc, soil(j)%phys(ly)%k, soil1(j)%tot(ly)%c, &
+                          soil(j)%phys(ly)%bd, soil(j)%phys(ly)%awc, soil(j)%phys(ly)%k, soil1(j)%tot(ly)%c/soil1(j)%tot(ly)%m * 100, &
                           soil(j)%phys(ly)%clay, soil(j)%phys(ly)%silt, soil(j)%phys(ly)%sand, soil(j)%phys(ly)%rock, &
                           soil(j)%ly(ly)%alb, soil(j)%ly(ly)%usle_k, soil(j)%ly(ly)%ec, soil(j)%ly(ly)%cal, soil(j)%ly(ly)%ph
             enddo

--- a/src/soil_nutcarb_write.f90
+++ b/src/soil_nutcarb_write.f90
@@ -328,7 +328,7 @@
         if (freq_label == "endsim") then
           do ly = 1, soil(j)%nly
             write (4584,*) freq_label, soil(j)%snam, ly, int(soil(j)%phys(ly)%d), time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, &
-                          soil(j)%phys(ly)%bd, soil(j)%phys(ly)%awc, soil(j)%phys(ly)%k, soil1(j)%tot(ly)%c, &
+                          soil(j)%phys(ly)%bd, soil(j)%phys(ly)%awc, soil(j)%phys(ly)%k, soil1(j)%tot(ly)%c/soil1(j)%tot(ly)%m * 100, &
                           soil(j)%phys(ly)%clay, soil(j)%phys(ly)%silt, soil(j)%phys(ly)%sand, soil(j)%phys(ly)%rock, &
                           soil(j)%ly(ly)%alb, soil(j)%ly(ly)%usle_k, soil(j)%ly(ly)%ec, soil(j)%ly(ly)%cal, soil(j)%ly(ly)%ph
           enddo

--- a/src/soil_nutcarb_write.f90
+++ b/src/soil_nutcarb_write.f90
@@ -30,7 +30,7 @@
       integer :: j = 0          !none        |counter
       integer :: iob = 0
       integer :: profile_depth
-      character (len=6) :: freq_label
+      character (len=7) :: freq_label
       logical :: layer_output
       logical :: print_soil_lyr_depths = .true.
       CHARACTER(LEN=15) :: str
@@ -53,8 +53,8 @@
         case ("yl")
           freq_label = "year"
           layer_output = .true.
-        case ("a")
-          freq_label = "av_ann"
+        case (" a")
+          freq_label = "endsim"
       end select
            
       !! basin output - zero daily basin outputs before summing
@@ -323,6 +323,26 @@
                           tot_prof_p, soil_prof_microb%p, soil_prof_lig%p, soil_prof_water%p, soil_prof_man%p
           endif 
         end if
+
+        ! write soil properties at the end of the simulation = "hru_endsim_soil_prop.txt/csv"
+        if (freq_label == "endsim") then
+          do ly = 1, soil(j)%nly
+            write (4584,*) freq_label, soil(j)%snam, ly, int(soil(j)%phys(ly)%d), time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, &
+                          soil(j)%phys(ly)%bd, soil(j)%phys(ly)%awc, soil(j)%phys(ly)%k, soil1(j)%tot(ly)%c, &
+                          soil(j)%phys(ly)%clay, soil(j)%phys(ly)%silt, soil(j)%phys(ly)%sand, soil(j)%phys(ly)%rock, &
+                          soil(j)%ly(ly)%alb, soil(j)%ly(ly)%usle_k, soil(j)%ly(ly)%ec, soil(j)%ly(ly)%cal, soil(j)%ly(ly)%ph
+          enddo
+          if (pco%csvout == "y") then
+            do ly = 1, soil(j)%nly
+              write (4585,'(*(G0.7,:,","))') freq_label, soil(j)%snam, ly, int(soil(j)%phys(ly)%d), time%day, time%mo, time%day_mo, time%yrc, j, ob(iob)%gis_id, ob(iob)%name, &
+                          soil(j)%phys(ly)%bd, soil(j)%phys(ly)%awc, soil(j)%phys(ly)%k, soil1(j)%tot(ly)%c, &
+                          soil(j)%phys(ly)%clay, soil(j)%phys(ly)%silt, soil(j)%phys(ly)%sand, soil(j)%phys(ly)%rock, &
+                          soil(j)%ly(ly)%alb, soil(j)%ly(ly)%usle_k, soil(j)%ly(ly)%ec, soil(j)%ly(ly)%cal, soil(j)%ly(ly)%ph
+            enddo
+          endif 
+        endif
+
+
 
       end do    !! hru loop
       


### PR DESCRIPTION
Changed code to output soil layer properties at the end of simulation.   The output file is called hru_endsim_soil_prop.txt/csv.  To output this file, the hru_cb print object must have the average annual set to "y".