### PR TITLE
Fixed an error where the soil layer number was not being set correctly in pl_dormant.f90.

### DIFF
--- a/src/pl_dormant.f90
+++ b/src/pl_dormant.f90
@@ -16,7 +16,6 @@
       integer :: idp = 0            !              |
       integer :: iob = 0            !              |
       integer :: iwgn = 0           !              |
-      integer :: ly = 0             !              |soil layer number
       real :: rto = 0.              !              |
       real :: lai_init = 0.         !
       real :: lai_drop = 0.
@@ -65,9 +64,9 @@
           
           soil1(j)%rsd(1) = soil1(j)%rsd(1) + abgr_drop
           if (bsn_cc%cswat == 2) then
-            soil1(j)%meta(ly) = soil1(j)%meta(ly) + 0.85 * abgr_drop
-            soil1(j)%str(ly) = soil1(j)%str(ly) + 0.15 * abgr_drop
-            soil1(j)%lig(ly) = soil1(j)%lig(ly) + 0.12 * abgr_drop  ! 0.12 = 0.8 * 0.15 -> lig = 80%str
+            soil1(j)%meta(1) = soil1(j)%meta(1) + 0.85 * abgr_drop
+            soil1(j)%str(1) = soil1(j)%str(1) + 0.15 * abgr_drop
+            soil1(j)%lig(1) = soil1(j)%lig(1) + 0.12 * abgr_drop  ! 0.12 = 0.8 * 0.15 -> lig = 80%str
           end if
           
         end if


### PR DESCRIPTION
Fixed an error where the soil layer number was not being set correctly in pl_dormant.f90 for the soil1(j)%meta, soil1(j)%str, and soil1(j)%lig arrays. The error was fixed by updating the soil layer number to 1, ensuring that the changes were applied to the correct layer.