### PR TITLE
Added the ability to read abco2,  prmt_21 and prmt_44 from files thus exposing them for sensitivity analysis and calibration

### DIFF
--- a/data/Ames_sub1/carbon_coef.cbn
+++ b/data/Ames_sub1/carbon_coef.cbn
@@ -1,4 +1,4 @@
 File: carbon_coef.cbn   Carbon coefficients used if cswat == 2
-hp_rate     hs_rate     microb_rate meta_rate   str_rate    microb_top_rate hs_hp   a1co2   asco2   apco2     
-1.2e-05     5.48e-04    0.0164      0.0405      0.0107      0.0164          0.05    0.55    0.55    0.55
-1.2e-05     5.48e-04    0.02        0.0507      0.0132      0.02            0.05    0.55    0.55    0.55
+hp_rate     hs_rate     microb_rate meta_rate   str_rate    microb_top_rate hs_hp   a1co2   asco2   apco2   abco2  
+1.2e-05     5.48e-04    0.0164      0.0405      0.0107      0.0164          0.05    0.55    0.55    0.55    0.95
+1.2e-05     5.48e-04    0.02        0.0507      0.0132      0.02            0.05    0.55    0.55    0.55    0.0

--- a/data/Ames_sub1/carbon_water_coef.cbn
+++ b/data/Ames_sub1/carbon_water_coef.cbn
@@ -1,0 +1,3 @@
+File: carbon_water_coef.cbn   Carbon water coefficients used in subroutine nut_orgnc2.f90 which is called if cswat ==2
+prmt_21 prmt_44
+1000.   0.5

--- a/src/carbon_coef_read.f90
+++ b/src/carbon_coef_read.f90
@@ -19,10 +19,10 @@ subroutine carbon_coef_read
           read (107,*,iostat=eof) header
           read (107,*,iostat=eof) carbdb(1)%hp_rate, carbdb(1)%hs_rate, carbdb(1)%microb_rate, &
                 carbdb(1)%meta_rate, carbdb(1)%str_rate, carbdb(1)%microb_top_rate, carbdb(1)%hs_hp, &
-                org_allo(1)%a1co2, org_allo(1)%asco2, org_allo(1)%apco2 
+                org_allo(1)%a1co2, org_allo(1)%asco2, org_allo(1)%apco2, org_allo(1)%abco2  
           read (107,*,iostat=eof) carbdb(2)%hp_rate, carbdb(2)%hs_rate, carbdb(2)%microb_rate, &
                 carbdb(2)%meta_rate, carbdb(2)%str_rate, carbdb(2)%microb_top_rate, carbdb(2)%hs_hp, &
-                org_allo(2)%a1co2, org_allo(2)%asco2, org_allo(2)%apco2 
+                org_allo(2)%a1co2, org_allo(2)%asco2, org_allo(2)%apco2, org_allo(2)%abco2 
           close (107)
           carbon_coef_file = .true.
         endif

--- a/src/carbon_module.f90
+++ b/src/carbon_module.f90
@@ -65,7 +65,6 @@
       logical :: carbon_coef_file = .false. !           !set to true if carbon_coef.cbn file exits.
       
       type organic_allocations
-          real :: abco2 = 0.      !               |Fraction of decomposed microbial biomass allocated to CO2
           ! real :: abl = 0.        !               |Fraction of microbial biomass loss due to leaching
           real :: abp = 0.        !               |Fraction of decomposed microbial biomass allocated to passive humus
           real :: asp = 0.        !               |Fraction of decomposed slow humus allocated to passive
@@ -75,6 +74,7 @@
           real :: a1co2 =  0.     !               |Fraction of decomposed metabolic and passive pools to CO2
           real :: asco2 = 0.      !               |Fraction of decomposed slow humus allocated to CO2
           real :: apco2 = 0.      !               |Fraction of decomposed  passive humus allocated to CO2
+          real :: abco2 = 0.      !               |Fraction of decomposed microbial biomass allocated to CO2
       end type organic_allocations
       type (organic_allocations), dimension(2) :: org_allo 
       type (organic_allocations) :: org_alloz

--- a/src/carbon_module.f90
+++ b/src/carbon_module.f90
@@ -113,6 +113,12 @@
       type (organic_ratio) :: org_ratio                   
       type (organic_ratio) :: org_ratio_zero                   
       
+      type carbon_water_coef
+          real :: prmt_21 = 1000.   !   |KOC FOR CARBON LOSS IN WATER AND SEDIMENT(500._1500.) KD = KOC * C          
+          real :: prmt_44 = 0.5     !   |RATIO OF SOLUBLE C CONCENTRATION IN RUNOFF TO PERCOLATE(0.1_1.)
+      end type carbon_water_coef
+      type (carbon_water_coef) :: cb_wtr_coef                  
+
       type organic_transformations
           real :: bmctp = 0.       !kg ha-1 day-1        |potential transformation of C in microbial biomass
           real :: bmntp = 0.       !kg ha-1 day-1        |potential transformation of N in microbial biomass

--- a/src/carbon_water_coef_read.f90
+++ b/src/carbon_water_coef_read.f90
@@ -1,0 +1,26 @@
+subroutine carbon_water_coef_read
+  ! read carbon water coefficients from file carbon_water_coef.cbn
+  ! 
+    use carbon_module
+    use basin_module
+    
+    implicit none
+
+    integer :: eof = 0                !           |end of file
+    logical :: i_exist = .false.      !           |true if file exists
+    character (len=80) :: titldum = ""!           |title of file
+    character (len=80) :: header = "" !           |header of file
+    
+    
+    if (bsn_cc%cswat == 2) then
+        inquire (file='carbon_water_coef.cbn', exist=i_exist)
+        if (i_exist) then
+          open (107,file='carbon_water_coef.cbn',recl = 1500)
+          read (107,*,iostat=eof) titldum
+          read (107,*,iostat=eof) header
+          read (107,*,iostat=eof) cb_wtr_coef
+          close (107)
+        endif
+    endif
+    return
+end subroutine                         

--- a/src/cbn_zhang2.f90
+++ b/src/cbn_zhang2.f90
@@ -297,7 +297,6 @@
         end if
         
         ! Initialize org_allo variables to zero except for a1co2, asco2, and apco2 because they are input values and don't change.
-        org_allo(cf_lyr)%abco2 = 0.
         org_allo(cf_lyr)%abp = 0.
         org_allo(cf_lyr)%asp = 0.
         soil1(j)%org_allo_lr(k) = org_allo(cf_lyr)   
@@ -414,7 +413,6 @@
 
           ! set nitrogen carbon ratios for upper layer
           if (k == 1) then
-            org_allo(cf_lyr)%abco2 = .55
             !carbdb%hs_rate=prmt(47) !century slow humus transformation rate d^-1(0.00041_0.00068) original value = 0.000548,
             if (.not. ufc) carbdb(cf_lyr)%hs_rate = 5.4799998e-04
             !carbdb%hp_rate=prmt(48) !century passive humus transformation rate d^-1(0.0000082_0.000015) original value = 0.000012 
@@ -426,6 +424,7 @@
             if (.not. ufc) org_allo(cf_lyr)%a1co2 = .55
             if (.not. ufc) org_allo(cf_lyr)%asco2 = .55
             if (.not. ufc) org_allo(cf_lyr)%apco2 = .55
+            if (.not. ufc) org_allo(cf_lyr)%abco2 = .55
             org_ratio%nchp = .1
             xbm = 1.
             ! org_con%cs = org_con%cs * carbdb(cf_lyr)%microb_top_rate

--- a/src/nut_orgnc2.f90
+++ b/src/nut_orgnc2.f90
@@ -122,8 +122,7 @@
           
         
       if (soil1(j)%microb(1)%c > .01) then
-          PRMT_21 = 0.  !KOC FOR CARBON LOSS IN WATER AND SEDIMENT(500._1500.) KD = KOC * C
-          PRMT_21 = 1000.
+          PRMT_21 = cb_wtr_coef%prmt_21 !KOC FOR CARBON LOSS IN WATER AND SEDIMENT(500._1500.) KD = KOC * C
           soil1(j)%tot(1)%c = soil1(j)%str(1)%c + soil1(j)%meta(1)%c + soil1(j)%hp(1)%c + soil1(j)%hs(1)%c + soil1(j)%microb(1)%c 
           DK = .0001 * PRMT_21 * soil1(j)%tot(1)%c
           !X1=PO(LD1)-S15(LD1)
@@ -137,8 +136,7 @@
           X3=0.
           IF(V>1.E-10)THEN
               X3 = soil1(j)%microb(1)%c * (1.-EXP(-V/XX)) !loss of biomass C
-              PRMT_44 = 0. !RATIO OF SOLUBLE C CONCENTRATION IN RUNOFF TO PERCOLATE(0.1_1.)
-              PRMT_44 = .5
+              PRMT_44 = cb_wtr_coef%prmt_44  !RATIO OF SOLUBLE C CONCENTRATION IN RUNOFF TO PERCOLATE(0.1_1.)
               CO = X3/(soil(j)%ly(1)%prk + PRMT_44 * (surfq(j) + soil(j)%ly(1)%flat)) !CS is the horizontal concentration
               CS = PRMT_44*CO                                     !CO is the vertical concentration
               VBC = CO*(soil(j)%ly(1)%prk) 

--- a/src/proc_bsn.f90
+++ b/src/proc_bsn.f90
@@ -28,6 +28,7 @@
       call basin_print_codes_read
       call co2_read
       call carbon_coef_read
+      call carbon_water_coef_read
    
       return
       


### PR DESCRIPTION
Added the ability to read in and use the carbon coefficient abco2 the carbon_coef_read.f90 file for the surface layer
Added the ability to read in and use prmt_21 and prmt_44 from a file named carbon_water_coef_read.cbn.   If that file  does not exist , these variables default to 1000. and 0.5 respectively.  These coefficients are used in nut_orgnc2 if cswat == 2.
Related to the preceding, added the subroutine carbon_water_coef_read.f90.

