### PR TITLE
Commented line in pl_fert to prevent double counting into liter pools.

### DIFF
--- a/src/pl_fert.f90
+++ b/src/pl_fert.f90
@@ -133,7 +133,7 @@
           soil1(j)%lig(l) = soil1(j)%lig(l) + 0.175 * pool_fr * org_frt
           
           !! total residue pool is metabolic + structural
-          soil1(j)%rsd(l) = soil1(j)%meta(l) + soil1(j)%str(l)
+          ! soil1(j)%rsd(l) = soil1(j)%meta(l) + soil1(j)%str(l)
           
         end if
         


### PR DESCRIPTION
Commented out the line that was causing double counting manure being partitioned into meta, str, and lignin pools.