### PR TITLE
Change to basin_print_codes_read.f90 to prevent gfortran allocation error and changes in harvesting residue.

### DIFF
--- a/src/basin_print_codes_read.f90
+++ b/src/basin_print_codes_read.f90
@@ -174,7 +174,6 @@
           if (eof < 0) exit
           read (107,*,iostat=eof) name, pco%cs_wet%d, pco%cs_wet%m, pco%cs_wet%y, pco%cs_wet%a
           if (eof < 0) exit
-          exit
         else
           do while (eof >= 0)
             read (107,*,iostat=eof) name
@@ -624,6 +623,7 @@
             end select
           end do
         end if
+        exit
       end do
       end if
       close (107)

--- a/src/mgt_harvresidue.f90
+++ b/src/mgt_harvresidue.f90
@@ -1,4 +1,4 @@
-      subroutine mgt_harvresidue (jj, harveff)
+      subroutine mgt_harvresidue (jj, harveff, iharvop)
 
 !!    ~ ~ ~ PURPOSE ~ ~ ~
 !!    this subroutine performs the harvest residue operation 
@@ -13,6 +13,7 @@
 
       use plant_module
       use carbon_module
+      use mgt_operations_module
       use organic_mineral_mass_module
       
       implicit none
@@ -20,20 +21,29 @@
       integer :: j = 0                  !none           |HRU number
       integer, intent (in) :: jj        !none           |hru number
       real, intent (in) :: harveff      !0-1            |harvest efficiency
+      real              :: eff          !0-1            |local scoope harvest efficiency
+      integer, intent (in) :: iharvop   !               |harvest operation type
       
       j = jj
+
+      if (harveff < .00001) then
+            eff = harvop_db(iharvop)%eff
+      else
+            eff = harveff
+      endif
       
       !! zero stover harvest
       hrc_d(j)%harv_stov_c = 0.
       
       !! harvest plant surface residue
-      soil1(j)%rsd(1) = (1. - harveff) * soil1(j)%rsd(1)
-      soil1(j)%meta(1) = (1. - harveff) * soil1(j)%meta(1)
-      soil1(j)%str(1) = (1. - harveff) * soil1(j)%str(1)
-      soil1(j)%lig(1) = (1. - harveff) * soil1(j)%lig(1)
+      soil1(j)%rsd(1) = (1. - eff) * soil1(j)%rsd(1)
+      ! soil1(j)%meta(1) = (1. - harveff) * soil1(j)%meta(1)
+      ! soil1(j)%str(1) = (1. - harveff) * soil1(j)%str(1)
+      ! soil1(j)%lig(1) = (1. - harveff) * soil1(j)%lig(1)
       
       !! compute carbon in harvested residue
-      hrc_d(j)%harv_stov_c = hrc_d(j)%harv_stov_c + 0.42 * (1. - harveff) * soil1(j)%rsd(1)%c
+      ! hrc_d(j)%harv_stov_c = hrc_d(j)%harv_stov_c + 0.42 * (1. - harveff) * soil1(j)%rsd(1)%c
+      hrc_d(j)%harv_stov_c = 0.42 * soil1(j)%rsd(1)%c
       
       return
       end  subroutine mgt_harvresidue

--- a/src/mgt_sched.f90
+++ b/src/mgt_sched.f90
@@ -139,78 +139,85 @@
 
             do ipl = 1, pcom(j)%npl
               if (pcom(j)%plcur(ipl)%gro == "y") then
-              biomass = pl_mass(j)%tot(ipl)%m
-              if (mgt%op_char == pcomdb(icom)%pl(ipl)%cpnm .or. mgt%op_char == "all") then
-                pcom(j)%days_harv = 1       !reset days since last harvest    
-                  
-                !check minimum biomass for harvest
-                if (biomass > harvop_db(iharvop)%bm_min) then
-                !harvest specific type
-                select case (harvop_db(iharvop)%typ)
-                case ("biomass")
-                  call mgt_harvbiomass (j, ipl, iharvop)
-                case ("grain")
-                  call mgt_harvgrain (j, ipl, iharvop)
-                case ("residue")
-                  harveff = mgt%op3
-                  call mgt_harvresidue (j, harveff)
-                case ("tree")
-                  call mgt_harvbiomass (j, ipl, iharvop)
-                case ("tuber")
-                  call mgt_harvtuber (j, ipl, iharvop)
-                case ("peanuts")
-                  call mgt_harvtuber (j, ipl, iharvop)
-                case ("stripper")
-                  call mgt_harvbiomass (j, ipl, iharvop)
-                case ("picker")
-                  call mgt_harvgrain (j, ipl, iharvop)
-                end select
-                end if
-
-                !! sum yield and number of harvest to calc ave yields
-                pl_mass(j)%yield_tot(ipl) = pl_mass(j)%yield_tot(ipl) + pl_yield
-                pl_mass(j)%yield_yr(ipl) = pl_mass(j)%yield_yr(ipl) + pl_yield
-                pcom(j)%plcur(ipl)%harv_num = pcom(j)%plcur(ipl)%harv_num + 1
-                pcom(j)%plcur(ipl)%harv_num_yr = pcom(j)%plcur(ipl)%harv_num_yr + 1
-                
-                !! sum basin crop yields and area harvested
-                iplt_bsn = pcom(j)%plcur(ipl)%bsn_num
-                bsn_crop_yld(iplt_bsn)%area_ha = bsn_crop_yld(iplt_bsn)%area_ha + hru(j)%area_ha
-                bsn_crop_yld(iplt_bsn)%yield = bsn_crop_yld(iplt_bsn)%yield + pl_yield%m * hru(j)%area_ha / 1000.
-                
-                !! sum regional crop yields for soft calibration
-                if (cal_codes%plt == "y") then
-                  if (hru(j)%crop_reg > 0) then
-                    ireg = hru(j)%crop_reg
-                    do ilum = 1, plcal(ireg)%lum_num
-                      if (plcal(ireg)%lum(ilum)%meas%name == mgt%op_char) then
-                        plcal(ireg)%lum(ilum)%ha = plcal(ireg)%lum(ilum)%ha + hru(j)%area_ha
-                        plcal(ireg)%lum(ilum)%sim%yield = plcal(ireg)%lum(ilum)%sim%yield + pl_yield%m * hru(j)%area_ha / 1000.
-                      end if
-                    end do
+                biomass = pl_mass(j)%tot(ipl)%m
+                if (mgt%op_char == pcomdb(icom)%pl(ipl)%cpnm .or. mgt%op_char == "all") then
+                  pcom(j)%days_harv = 1       !reset days since last harvest    
+                    
+                  !check minimum biomass for harvest
+                  if (biomass > harvop_db(iharvop)%bm_min) then
+                    !harvest specific type
+                    select case (harvop_db(iharvop)%typ)
+                    case ("biomass")
+                      call mgt_harvbiomass (j, ipl, iharvop)
+                    case ("grain")
+                      call mgt_harvgrain (j, ipl, iharvop)
+                    case ("residue")
+                      harveff = mgt%op3
+                      call mgt_harvresidue (j, harveff, iharvop)
+                    case ("tree")
+                      call mgt_harvbiomass (j, ipl, iharvop)
+                    case ("tuber")
+                      call mgt_harvtuber (j, ipl, iharvop)
+                    case ("peanuts")
+                      call mgt_harvtuber (j, ipl, iharvop)
+                    case ("stripper")
+                      call mgt_harvbiomass (j, ipl, iharvop)
+                    case ("picker")
+                      call mgt_harvgrain (j, ipl, iharvop)
+                    end select
                   end if
+
+                  !! sum yield and number of harvest to calc ave yields
+                  pl_mass(j)%yield_tot(ipl) = pl_mass(j)%yield_tot(ipl) + pl_yield
+                  pl_mass(j)%yield_yr(ipl) = pl_mass(j)%yield_yr(ipl) + pl_yield
+                  pcom(j)%plcur(ipl)%harv_num = pcom(j)%plcur(ipl)%harv_num + 1
+                  pcom(j)%plcur(ipl)%harv_num_yr = pcom(j)%plcur(ipl)%harv_num_yr + 1
+                  
+                  !! sum basin crop yields and area harvested
+                  iplt_bsn = pcom(j)%plcur(ipl)%bsn_num
+                  bsn_crop_yld(iplt_bsn)%area_ha = bsn_crop_yld(iplt_bsn)%area_ha + hru(j)%area_ha
+                  bsn_crop_yld(iplt_bsn)%yield = bsn_crop_yld(iplt_bsn)%yield + pl_yield%m * hru(j)%area_ha / 1000.
+                  
+                  !! sum regional crop yields for soft calibration
+                  if (cal_codes%plt == "y") then
+                    if (hru(j)%crop_reg > 0) then
+                      ireg = hru(j)%crop_reg
+                      do ilum = 1, plcal(ireg)%lum_num
+                        if (plcal(ireg)%lum(ilum)%meas%name == mgt%op_char) then
+                          plcal(ireg)%lum(ilum)%ha = plcal(ireg)%lum(ilum)%ha + hru(j)%area_ha
+                          plcal(ireg)%lum(ilum)%sim%yield = plcal(ireg)%lum(ilum)%sim%yield + pl_yield%m * hru(j)%area_ha / 1000.
+                        end if
+                      end do
+                    end if
+                  end if
+              
+                  idp = pcom(j)%plcur(ipl)%idplt
+                  if (pco%mgtout == "y") then
+                    write (2612, *) j, time%yrc, time%mo, time%day_mo,  pldb(idp)%plantnm, "    HARVEST ",    &
+                        phubase(j), pcom(j)%plcur(ipl)%phuacc, soil(j)%sw, biomass, soil1(j)%rsd(1)%m,   &
+                        sol_sumno3(j), sol_sumsolp(j), pl_yield%m, pcom(j)%plstr(ipl)%sum_n,              &
+                        pcom(j)%plstr(ipl)%sum_p, pcom(j)%plstr(ipl)%sum_tmp, pcom(j)%plstr(ipl)%sum_w,   &
+                        pcom(j)%plstr(ipl)%sum_a
+                  end if 
                 end if
-            
-                idp = pcom(j)%plcur(ipl)%idplt
-                if (pco%mgtout == "y") then
-                  write (2612, *) j, time%yrc, time%mo, time%day_mo,  pldb(idp)%plantnm, "    HARVEST ",    &
-                      phubase(j), pcom(j)%plcur(ipl)%phuacc, soil(j)%sw, biomass, soil1(j)%rsd(1)%m,   &
-                      sol_sumno3(j), sol_sumsolp(j), pl_yield%m, pcom(j)%plstr(ipl)%sum_n,              &
-                      pcom(j)%plstr(ipl)%sum_p, pcom(j)%plstr(ipl)%sum_tmp, pcom(j)%plstr(ipl)%sum_w,   &
-                      pcom(j)%plstr(ipl)%sum_a
-                end if 
-              end if
               !pcom(j)%plcur(ipl)%phuacc = 0.
+              else   ! for when the crop is not living.
+                select case (harvop_db(iharvop)%typ)
+                  case ("residue")
+                    harveff = mgt%op3
+                    call mgt_harvresidue (j, harveff, iharvop)
+                end select
               end if
             end do
           
-            case ("kill")   !! kill operation
-              do ipl = 1, pcom(j)%npl
+          case ("kill")   !! kill operation
+            do ipl = 1, pcom(j)%npl
+              if (pcom(j)%plcur(ipl)%gro == "y") then
                 biomass = pl_mass(j)%tot(ipl)%m
                 if (mgt%op_char == pcomdb(icom)%pl(ipl)%cpnm .or. mgt%op_char == "all") then
                   pcom(j)%days_kill = 1       !reset days since last kill   
                   call mgt_killop (j, ipl)
-  
+
                   idp = pcom(j)%plcur(ipl)%idplt
                   if (pco%mgtout == "y") then
                     write (2612, *) j, time%yrc, time%mo, time%day_mo,  pldb(idp)%plantnm, "    KILL ",  &
@@ -219,79 +226,89 @@
                       pcom(j)%plstr(ipl)%sum_p, pcom(j)%plstr(ipl)%sum_tmp, pcom(j)%plstr(ipl)%sum_w,   &
                       pcom(j)%plstr(ipl)%sum_a
                   end if 
-                end if
-                pcom(j)%plcur(ipl)%phuacc = 0.
-              end do
+                endif
+              end if
+              pcom(j)%plcur(ipl)%phuacc = 0.
+            end do
        
           case ("hvkl")   !! harvest and kill operation
             iharvop = mgt%op1
 
             do ipl = 1, pcom(j)%npl
+              if (pcom(j)%plcur(ipl)%gro == "y") then
               biomass = pl_mass(j)%tot(ipl)%m
-              if (mgt%op_char == pcomdb(icom)%pl(ipl)%cpnm .or. mgt%op_char == "all") then
-                pcom(j)%days_harv = 1       !reset days since last harvest
-                pcom(j)%days_kill = 1       !reset days since last kill       
+                if (mgt%op_char == pcomdb(icom)%pl(ipl)%cpnm .or. mgt%op_char == "all") then
+                  pcom(j)%days_harv = 1       !reset days since last harvest
+                  pcom(j)%days_kill = 1       !reset days since last kill       
+                    
+                  !check minimum biomass for harvest
+                  if (biomass > harvop_db(iharvop)%bm_min) then
+                    !harvest specific type
+                    select case (harvop_db(iharvop)%typ)
+                      case ("biomass")    
+                        call mgt_harvbiomass (j, ipl, iharvop)
+                      case ("grain")
+                        call mgt_harvgrain (j, ipl, iharvop)
+                      case ("residue")
+                        harveff = mgt%op3
+                        call mgt_harvresidue (j, harveff, iharvop)
+                      case ("tree")
+                      case ("tuber")
+                        call mgt_harvtuber (j, ipl, iharvop)
+                      case ("peanuts")
+                        call mgt_harvtuber (j, ipl, iharvop)
+                      case ("stripper")
+                        call mgt_harvgrain (j, ipl, iharvop)
+                      case ("picker")
+                        call mgt_harvgrain (j, ipl, iharvop)
+                    end select
+                  end if
+
+                  call mgt_killop (j, ipl)
+
+                  !! sum yield and num. of harvest to calc ave yields
+                  pl_mass(j)%yield_tot(ipl) = pl_mass(j)%yield_tot(ipl) + pl_yield
+                  pl_mass(j)%yield_yr(ipl) = pl_mass(j)%yield_yr(ipl) + pl_yield
+                  pcom(j)%plcur(ipl)%harv_num = pcom(j)%plcur(ipl)%harv_num + 1
+                  pcom(j)%plcur(ipl)%harv_num_yr = pcom(j)%plcur(ipl)%harv_num_yr + 1
                   
-                !check minimum biomass for harvest
-                if (biomass > harvop_db(iharvop)%bm_min) then
-                !harvest specific type
+                  !! sum basin crop yields and area harvested
+                  iplt_bsn = pcom(j)%plcur(ipl)%bsn_num
+                  bsn_crop_yld(iplt_bsn)%area_ha = bsn_crop_yld(iplt_bsn)%area_ha + hru(j)%area_ha
+                  bsn_crop_yld(iplt_bsn)%yield = bsn_crop_yld(iplt_bsn)%yield + pl_yield%m * hru(j)%area_ha / 1000.
+                  
+                  !! sum regional crop yields for soft calibration
+                  if (cal_codes%plt == "y") then
+                    ireg = hru(j)%crop_reg
+                    do ilum = 1, plcal(ireg)%lum_num
+                      if (plcal(ireg)%lum(ilum)%meas%name == mgt%op_char) then
+                        plcal(ireg)%lum(ilum)%ha = plcal(ireg)%lum(ilum)%ha + hru(j)%area_ha
+                        plcal(ireg)%lum(ilum)%sim%yield = plcal(ireg)%lum(ilum)%sim%yield + pl_yield%m * hru(j)%area_ha / 1000.
+                      end if
+                    end do
+                  end if
+              
+                  idp = pcom(j)%plcur(ipl)%idplt
+                  if (pco%mgtout == "y") then
+                    write (2612, *) j, time%yrc, time%mo, time%day_mo,  pldb(idp)%plantnm, "    HARV/KILL ",      &
+                        phubase(j), pcom(j)%plcur(ipl)%phuacc, soil(j)%sw, biomass, soil1(j)%rsd(1)%m,           &
+                        sol_sumno3(j), sol_sumsolp(j), pl_yield%m, pcom(j)%plstr(ipl)%sum_n,                      &
+                        pcom(j)%plstr(ipl)%sum_p, pcom(j)%plstr(ipl)%sum_tmp, pcom(j)%plstr(ipl)%sum_w,           &
+                        pcom(j)%plstr(ipl)%sum_a
+                  end if 
+                end if
+                pcom(j)%plstr(ipl) = plstrz
+                pcom(j)%plcur(ipl)%phuacc = 0.
+                phubase(j) = 0.
+              else
                 select case (harvop_db(iharvop)%typ)
-                case ("biomass")    
-                  call mgt_harvbiomass (j, ipl, iharvop)
-                case ("grain")
-                  call mgt_harvgrain (j, ipl, iharvop)
-                case ("residue")
-                  harveff = mgt%op3
-                  call mgt_harvresidue (j, harveff)
-                case ("tree")
-                case ("tuber")
-                  call mgt_harvtuber (j, ipl, iharvop)
-                case ("peanuts")
-                  call mgt_harvtuber (j, ipl, iharvop)
-                case ("stripper")
-                  call mgt_harvgrain (j, ipl, iharvop)
-                case ("picker")
-                  call mgt_harvgrain (j, ipl, iharvop)
+                  case ("residue")
+                    harveff = mgt%op3
+                    call mgt_harvresidue (j, harveff, iharvop)
                 end select
-                end if
-
-                call mgt_killop (j, ipl)
-
-                !! sum yield and num. of harvest to calc ave yields
-                pl_mass(j)%yield_tot(ipl) = pl_mass(j)%yield_tot(ipl) + pl_yield
-                pl_mass(j)%yield_yr(ipl) = pl_mass(j)%yield_yr(ipl) + pl_yield
-                pcom(j)%plcur(ipl)%harv_num = pcom(j)%plcur(ipl)%harv_num + 1
-                pcom(j)%plcur(ipl)%harv_num_yr = pcom(j)%plcur(ipl)%harv_num_yr + 1
-                
-                !! sum basin crop yields and area harvested
-                iplt_bsn = pcom(j)%plcur(ipl)%bsn_num
-                bsn_crop_yld(iplt_bsn)%area_ha = bsn_crop_yld(iplt_bsn)%area_ha + hru(j)%area_ha
-                bsn_crop_yld(iplt_bsn)%yield = bsn_crop_yld(iplt_bsn)%yield + pl_yield%m * hru(j)%area_ha / 1000.
-                
-                !! sum regional crop yields for soft calibration
-                if (cal_codes%plt == "y") then
-                  ireg = hru(j)%crop_reg
-                  do ilum = 1, plcal(ireg)%lum_num
-                    if (plcal(ireg)%lum(ilum)%meas%name == mgt%op_char) then
-                      plcal(ireg)%lum(ilum)%ha = plcal(ireg)%lum(ilum)%ha + hru(j)%area_ha
-                      plcal(ireg)%lum(ilum)%sim%yield = plcal(ireg)%lum(ilum)%sim%yield + pl_yield%m * hru(j)%area_ha / 1000.
-                    end if
-                  end do
-                end if
-            
-                idp = pcom(j)%plcur(ipl)%idplt
-                if (pco%mgtout == "y") then
-                  write (2612, *) j, time%yrc, time%mo, time%day_mo,  pldb(idp)%plantnm, "    HARV/KILL ",      &
-                      phubase(j), pcom(j)%plcur(ipl)%phuacc, soil(j)%sw, biomass, soil1(j)%rsd(1)%m,           &
-                      sol_sumno3(j), sol_sumsolp(j), pl_yield%m, pcom(j)%plstr(ipl)%sum_n,                      &
-                      pcom(j)%plstr(ipl)%sum_p, pcom(j)%plstr(ipl)%sum_tmp, pcom(j)%plstr(ipl)%sum_w,           &
-                      pcom(j)%plstr(ipl)%sum_a
-                end if 
-              end if
-              pcom(j)%plstr(ipl) = plstrz
-              pcom(j)%plcur(ipl)%phuacc = 0.
-              phubase(j) = 0.
+              endif
             end do
+
           case ("till")   !! tillage operation
             idtill = mgt%op1
             ipl = Max(1, mgt%op2)


### PR DESCRIPTION
Minor change to basin_print_codes_read.f90 to prevent gfortran allocation error when reading print object labels.

Modified mgt_harvresidue.f90 to use harvest efficiency from harv.ops input file if harvest efficiency in management schedule is zero (mgt%opt3)  and commented out code that was taking residue from meta, str, and lig pools and corrected code that was double reducing the carbon amount in the harvested residue carbon pool.

Modified mgt_sched.f90 to allow harvesting of residue when the crop is not living (i.e. after the crop has been killed) and modified the call to mgt_harvesresidue and modified the code to prevent killing crop that what was no longer growing (i.e. had previously been killed).