### PR TITLE
Changes to use surface temperature of soil to determine when surface …

### DIFF
--- a/src/cbn_surfrsd_decomp.f90
+++ b/src/cbn_surfrsd_decomp.f90
@@ -32,7 +32,7 @@
       use septic_data_module
       use basin_module
       use organic_mineral_mass_module
-      use hru_module, only : ihru, isep 
+      use hru_module, only : ihru
       use soil_module
       use plant_module
       use plant_data_module

--- a/src/cbn_surfrsd_decomp_3.f90
+++ b/src/cbn_surfrsd_decomp_3.f90
@@ -39,7 +39,10 @@
       use output_landscape_module, only : hnb_d
       
       implicit none 
+       
+      external :: fcgd
 
+      real :: fcgd
       integer :: j = 0      !none          |HRU number
       real :: rmn1 = 0.     !kg N/ha       |amount of nitrogen moving from fresh organic
                             !              |to nitrate(80%) and active organic(20%)
@@ -59,6 +62,9 @@
       real :: sut = 0.      !none          |soil water factor
       real :: nactfr = 0.   !none          |nitrogen active pool fraction. The fraction
                             !              |of organic nitrogen in the active pool. 
+      real :: fc            !mm            |total water content at field capacity
+      real :: wc            !mm            |total current water content
+
       j = ihru
       nactfr = .02
       !zero transformations for summing layers
@@ -77,14 +83,26 @@
           pl_mass(j)%rsd(ipl) = pl_mass(j)%rsd(ipl) - photo_decomp
           pl_mass(j)%rsd_tot = pl_mass(j)%rsd_tot - photo_decomp
           if (soil(j)%phys(1)%tmp > 0.) then
-            !! compute soil water factor
+          ! if (soil(j)%tmp_srf > 0.) then !! compute soil water factor
+          !   fc = soil(j)%phys(1)%fc + soil(j)%phys(1)%wpmm        ! units mm
+          !   wc = soil(j)%phys(1)%st + soil(j)%phys(1)%wpmm        ! units mm
+          !   if (wc - soil(j)%phys(1)%wpmm < 0.) then
+          !     sut = .1 * (soil(j)%phys(11)%st /soil(j)%phys(1)%wpmm) ** 2
+          !   else
+          !     sut = .1 + .9 * sqrt(soil(j)%phys(1)%st / soil(j)%phys(1)%fc)
+          !   endif
+          !   sut = min(1., org_con%sut)
+          !   sut = max(.05, org_con%sut)
+            
             sut = .1 + .9 * Sqrt(soil(j)%phys(1)%st / soil(j)%phys(1)%fc)
             sut = Max(.05, sut)
 
             !!compute soil temperature factor
+            ! cdg = fcgd(soil(j)%tmp_srf)
             xx = soil(j)%phys(1)%tmp
             cdg = .9 * xx / (xx + Exp(9.93 - .312 * xx)) + .1
             cdg = Max(.1, cdg)
+            !! compute soil water factor
 
             !! compute combined factor
             xx = cdg * sut

--- a/src/cbn_zhang2.f90
+++ b/src/cbn_zhang2.f90
@@ -344,34 +344,10 @@
 
             case(3)
 
+              ! This case uses the tillagf factor developed by Armen 16 January 2008 and is determined 
+              ! in the subroutine mgt_tillagef subroutine prior to running this subroutine.
               tf = soil(j)%ly(k)%tillagef 
-              if (tillage_switch(j) .eq. 1 .and. tillage_days(j) .le. till_eff_days) then
-                ! Kemanian method    ----having modi
-                ! org_con%till_eff = 1. + soil(j)%ly(k)%tillagef 
-                org_con%till_eff = 1. + tf
-              else
-                ! Changed by fg to always have some bio mixing
-                if (soil(j)%phys(k)%d <= bmix_depth) then            
-                  ! org_con%till_eff = 1.0 + hru(j)%hyd%biomix
-                  ! org_con%till_eff = 1.0 + soil(j)%ly(k)%tillagef
-                  org_con%till_eff = 1.0 + tf
-                else
-
-                  if (k == 1) then
-                    soil_lyr_thickness = soil(j)%phys(k)%d - 0.
-                  else
-                    soil_lyr_thickness = soil(j)%phys(k)%d - soil(j)%phys(k-1)%d
-                  end if
-
-                  if (soil(j)%phys(k)%d > bmix_depth .and. soil(j)%phys(k-1)%d < bmix_depth) then 
-                    ! org_con%till_eff = 1.0 + (soil(j)%ly(k)%tillagef * (bmix_depth - soil(j)%phys(k-1)%d) / soil_lyr_thickness)  
-                    org_con%till_eff = 1.0 + (tf * (bmix_depth - soil(j)%phys(k-1)%d) / soil_lyr_thickness)  
-                  else
-                    org_con%till_eff = 1.0
-                  end if
-                  
-                end if
-              endif
+              org_con%till_eff = 1. + soil(j)%ly(k)%tillagef 
 
             case(4)
               ! place holder for dndc method

--- a/src/hru_control.f90
+++ b/src/hru_control.f90
@@ -51,7 +51,7 @@
                   smp_grass_wway, sq_canopyint, sq_snom, sq_surfst, stmp_solt, stor_surfstor, surface, &
                   swr_latsed, swr_percmain, swr_substor, swr_subwq, varinit, wet_irrp, wetland_control, &
                   sq_crackvol, mgt_operatn, mgt_newtillmix, sep_biozone, pest_washp, pest_pesty, smp_buffer, &
-                  mgt_newtillmix_3, cbn_surfrsd_decomp, cbn_rsd_transfer, cbn_surfrsd_decomp_3
+                  mgt_newtillmix_3, cbn_surfrsd_decomp, cbn_rsd_transfer, cbn_surfrsd_decomp_3, mgt_biomix
 
       integer :: j = 0              !none          |same as ihru (hru number)
       integer :: j1 = 0             !none          |counter (rtb)

--- a/src/mgt_biomix.f90
+++ b/src/mgt_biomix.f90
@@ -130,7 +130,6 @@
           ! Calculated a temperature weighted average of emix 
           emix_sum = 0.
           do l = 1, soil(jj)%nly
-            if (l == 3) soil(jj)%phys(l)%tmp = -1.
             if (soil(jj)%phys(l)%tmp > 1.e-6) then
               if (soil(jj)%phys(l)%d <= dtil) then
                 emix = bmix

--- a/src/mgt_tillfactor.f90
+++ b/src/mgt_tillfactor.f90
@@ -56,13 +56,14 @@
         if (emix > 1.e-6) then
 
           xx = 0.
-          ! zz = 3. + (8. - 3.)*exp(-5.5*soil(jj)%phys(l)%clay/100.)
+          ! zz = 3. + (8. - 3.)*exp(-5.5*soil(jj)%phys(l)%clay/100.) <- original equation.
           if (bio_mix_event) then
-            yy = 0.
-            soil(jj)%ly(l)%tillagef = 0.
             zz = zz_bmix_coef_a + (zz_bmix_coef_b)*exp(zz_bmix_coef_c*soil(jj)%phys(l)%clay/100.)
+            ! for a biomix event, the previous tillagef is set to zero in the mgt_biomix subroutine
+            ! because it should not be cumulative so yy will always be zero for biomix event.
+            yy = soil(jj)%ly(l)%tillagef / zz
           else
-            ! zz = 3. + (15. - 3.)*exp(-5.5*soil(jj)%phys(l)%clay/100.)
+            ! zz = 3. + (15. - 3.)*exp(-5.5*soil(jj)%phys(l)%clay/100.) <- original equation.
             zz = zz_emix_coef_a + (zz_emix_coef_b)*exp(zz_emix_coef_c*soil(jj)%phys(l)%clay/100.)
             yy = soil(jj)%ly(l)%tillagef / zz
           endif
@@ -71,10 +72,10 @@
 
           ! empirical solution for x when y is known and y=x/(x+exp(m1-m2*x)) 
           if (yy > 0.01) then
-          xx1 = yy ** exp_w(-0.13 + 1.06 * yy)
-          ! xx2 = exp_w(0.64 + 0.64 * yy ** 100.)   ! This causes an arithmatic error that is ignored by intel but not by gfortran
-          xx2 = exp_w(0.64 + 0.64 * yy ** 10.)
-          xx = xx1 * xx2
+            xx1 = yy ** exp_w(-0.13 + 1.06 * yy)
+            ! xx2 = exp_w(0.64 + 0.64 * yy ** 100.)   ! This causes an arithmatic error that is ignored by intel but not by gfortran
+            xx2 = exp_w(0.64 + 0.64 * yy ** 10.)
+            xx = xx1 * xx2
           end if
 
           csdr = xx + emix

--- a/src/soil_module.f90
+++ b/src/soil_module.f90
@@ -93,6 +93,7 @@
         real :: wat_tbl = 0.               !! 
         real :: avpor = 0.                 !! none           average porosity for entire soil profile
         real :: avbd = 0.                  !! Mg/m^3         average bulk density for soil profile
+        real :: tmp_srf = 0.               !! celsius        surface temperature of the soil
       end type soil_profile
       type (soil_profile), dimension(:), allocatable :: soil
       type (soil_profile), dimension(:), allocatable :: soil_init

--- a/src/stmp_solt.f90
+++ b/src/stmp_solt.f90
@@ -49,7 +49,6 @@
       real :: bcv = 0.           !none          |lagging factor for cover
       real :: tbare = 0.         !deg C         |temperature of bare soil surface
       real :: tcov = 0.          !deg C         |temperature of soil surface corrected for cover
-      real :: tmp_srf = 0.       !deg C         |temperature of soil surface
       real :: cover = 0.         !kg/ha         |soil cover
 
       j = ihru
@@ -100,7 +99,7 @@
       st0 = 0.
       tbare = 0.
       tcov = 0.
-      tmp_srf = 0.
+      soil(j)%tmp_srf = 0.
       !! SWAT manual equation 2.3.10
       st0 = (w%solrad * (1. - albday) - 14.) / 20.
       !! SWAT manual equation 2.3.9
@@ -112,7 +111,7 @@
 !!    previously using minimum causing soil temp to decrease
 !!    in summer due to high biomass
 
-      tmp_srf = 0.5 * (tbare + tcov)  ! following Jimmy"s code
+      soil(j)%tmp_srf = 0.5 * (tbare + tcov)  ! following Jimmy"s code
 
 !! calculate temperature for each layer on current day
       xx = 0.
@@ -125,7 +124,7 @@
         df = zd / (zd + Exp(-.8669 - 2.0775 * zd))
         !! SWAT manual equation 2.3.3
         soil(j)%phys(k)%tmp = tlag * soil(j)%phys(k)%tmp + (1. - tlag) *       &
-                      (df * (wgn_pms(iwgen)%tmp_an - tmp_srf) + tmp_srf)
+                      (df * (wgn_pms(iwgen)%tmp_an - soil(j)%tmp_srf) + soil(j)%tmp_srf)
         xx = soil(j)%phys(k)%d
 
         ! Temperature correction for Onsite Septic systems

--- a/src/tillage_data_module.f90
+++ b/src/tillage_data_module.f90
@@ -5,7 +5,8 @@
       integer :: bmix_idtill = 0    !!              |none          |the tilldb index of the biomix tillage. 
       integer :: till_eff_days = 30  !!              |none          |length of days a tillage operation will have an effect
       real    :: bmix_eff = 0.      !!              |none          |biological mixing efficieny
-      real    :: bmix_depth = 0.    !!              |none          |biological mixing depth
+      real    :: bmix_depth = 0.    !!              |mm            |maximum potential biological mixing depth
+      real    :: dtill      = 0.    !!              |mm            |actual biological or tillage mixing  mixing depth
       real    :: zz_bmix_coef_a = 3.0    !!              |none          !Base intercept in zz equation in mgt_tillfactor.f90 for biomixing
       real    :: zz_bmix_coef_b = 5.0   !!              |none          !slope of in zz equation in mgt_tillfactor.f90 for biomixing 
       real    :: zz_bmix_coef_c = -5.5   !!              |none          !exponent multiplier in zz equation in mgt_tillfactor.f90 for biomixing


### PR DESCRIPTION
…residue decomposition occurs. Removed unnecessary code from cbn_zhang2 resulting because biomixing is being handled elsewhere in the code.  Removed debug statement mgt_biomix.f90 that was setting the third soil layer to temperature to -1.