### PR TITLE
fixed mgt_harvresidue.f90 subroutine. Added write statement mgt_sched for harvest residue, fixed spelling error in harv.ops in reference data and ..

### DIFF
--- a/refdata/Ames_sub1/harv.ops
+++ b/refdata/Ames_sub1/harv.ops
@@ -1,18 +1,18 @@
-harv.ops: written by SWAT+ editor v2.3.3 on 2023-10-25 08:58 for SWAT+ rev.60.5.7
-name                      harv_typ      harv_idx      harv_eff   harv_bm_min  description
-forest_cut                    tree       0.95000       0.99000       0.00000  
-grain                        grain       0.00000       0.95000       0.00000  
-grass_bag                  biomass       0.50000       1.00000    2000.00000  
-grass_mulch                biomass       0.50000       0.00000    2000.00000  
-hay_cut_high               biomass       0.80000       1.00000    3000.00000  
-hay_cut_low                biomass       0.80000       1.00000    1000.00000  
-orchard                    biomass       0.01000       1.00000       0.00000  
-peanuts                      tuber       1.10000       0.95000       0.00000  
-tuber                        tuber       1.10000       0.95000       0.00000  
-silage                     biomass       0.90000       0.95000       0.00000  
-stover_high                residue       0.90000       1.00000    1000.00000  
-stover_los                 residue       0.30000       1.00000    3000.00000  
-stover_med                 residue       0.60000       1.00000    2000.00000  
-vegetables                 biomass       0.50000       1.00000    2000.00000  
-cotton_picker                grain       0.05000       0.95000       0.00000  
-cotton_strip                 grain       0.05000       0.95000       0.00000  
+harv_ops Generated from M:\Constructor\HUC8_models\models\07100007.accdb Time: 2/2/2024 4:13:37 PM
+           NAME  HARV_TYP  HARV_IDX  HARV_EFF  HARV_BM_MIN
+  cotton_picker     grain      0.05      0.95            0
+   cotton_strip     grain      0.05      0.95            0
+     forest_cut      tree      0.95      0.99            0
+          grain     grain         0      0.95            0
+      grass_bag   biomass       0.5         1         2000
+    grass_mulch   biomass       0.5         0         2000
+   hay_cut_high   biomass       0.8         1         3000
+    hay_cut_low   biomass       0.8         1         1000
+        orchard   biomass      0.01         1            0
+        peanuts     tuber       1.1      0.95            0
+         silage   biomass       0.9      0.95            0
+    stover_high   residue       0.9         1         1000
+     stover_low   residue       0.3         1         3000
+     stover_med   residue       0.6         1         2000
+          tuber     tuber       1.1      0.95            0
+     vegetables   biomass       0.5         1         2000

--- a/src/command.f90
+++ b/src/command.f90
@@ -73,7 +73,7 @@
 
       icmd = sp_ob1%objs
       wallo(:)%trn_cur = 1
-      res_ob(:)%wallo_call = 0
+      if (allocated(res_ob)) res_ob(:)%wallo_call = 0
       
       do while (icmd /= 0)
           

--- a/src/mgt_harvresidue.f90
+++ b/src/mgt_harvresidue.f90
@@ -18,12 +18,18 @@
       
       implicit none
  
-      integer :: j = 0                  !none           |HRU number
       integer, intent (in) :: jj        !none           |hru number
       real, intent (in) :: harveff      !0-1            |harvest efficiency
+      type (organic_mass) :: rsd_removed
       real              :: eff          !0-1            |local scoope harvest efficiency
+      real    :: harv_idx               !none           |harvest index 
+      real    :: net_eff                !none           |equipment efficiency times harvest efficiency 
+      real    :: reduction_frac         !               |fractional adjustment if residue remaining is than bm_min
+      real    :: bm_min                 !               |minimum biomass that must remain after residue removal 
       integer, intent (in) :: iharvop   !               |harvest operation type
       integer :: ipl = 0                !none           |sequential plant number
+      integer :: j = 0
+
       
       j = jj
       !! prevent the harvest efficiency from being too small
@@ -32,17 +38,39 @@
       else
             eff = harveff
       endif
+      harv_idx = harvop_db(iharvop)%hi_ovr
+      bm_min = harvop_db(iharvop)%bm_min
+      net_eff = eff * harv_idx
       
       !! zero stover harvest
       hrc_d(j)%harv_stov_c = 0.
       
-      pl_mass(j)%rsd_tot = orgz
+      ! pl_mass(j)%rsd_tot = orgz
       !! harvest plant surface residue
+      rsd_removed = orgz
       do ipl = 1, pcom(j)%npl
-        pl_mass(j)%rsd(ipl) = (1. - eff) * pl_mass(j)%rsd(ipl) 
-        pl_mass(j)%rsd_tot = pl_mass(j)%rsd_tot + pl_mass(j)%rsd(ipl)
-        !! compute carbon in harvested residue
-        hrc_d(j)%harv_stov_c = pl_mass(j)%rsd_tot%c / eff - pl_mass(j)%rsd_tot%c
+      !   pl_mass(j)%rsd(ipl) = (1. - eff) * pl_mass(j)%rsd(ipl) 
+      !   pl_mass(j)%rsd_tot = pl_mass(j)%rsd_tot + pl_mass(j)%rsd(ipl)
+      !!  compute carbon in harvested residue
+      !   hrc_d(j)%harv_stov_c = (pl_mass(j)%rsd_tot%c / eff) - pl_mass(j)%rsd_tot%c
+
+        rsd_removed = net_eff * pl_mass(j)%rsd(ipl)
+
+        ! Check to see if more residue was removed than allowed
+        if ((pl_mass(j)%rsd(ipl)%m - rsd_removed%m) < bm_min) then
+            reduction_frac = (pl_mass(j)%rsd(ipl)%m - bm_min) / pl_mass(j)%rsd(ipl)%m
+            rsd_removed = reduction_frac * pl_mass(j)%rsd(ipl)
+        endif
+
+        pl_mass(j)%rsd(ipl) = pl_mass(j)%rsd(ipl) - rsd_removed 
+        pl_mass(j)%rsd_tot = pl_mass(j)%rsd_tot - rsd_removed
+        if (pl_mass(j)%rsd_tot%m < 1.e-6) then
+          pl_mass(j)%rsd_tot = orgz
+        endif
+
+        hrc_d(j)%harv_stov_c = rsd_removed%c
+
+
       end do
       
       return

--- a/src/mgt_sched.f90
+++ b/src/mgt_sched.f90
@@ -224,6 +224,13 @@
                     harveff = mgt%op3
                     call mgt_harvresidue (j, harveff, iharvop)
                 end select
+                if (pco%mgtout == "y") then
+                  write (2612, *) j, time%yrc, time%mo, time%day_mo,  pldb(idp)%plantnm, "    HARVEST ",  &
+                      phubase(j), pcom(j)%plcur(ipl)%phuacc, soil(j)%sw, biomass, pl_mass(j)%rsd_tot%m,   &
+                      sol_sumno3(j), sol_sumsolp(j), pl_yield%m, pcom(j)%plstr(ipl)%sum_n,                &
+                      pcom(j)%plstr(ipl)%sum_p, pcom(j)%plstr(ipl)%sum_tmp, pcom(j)%plstr(ipl)%sum_w,     &
+                      pcom(j)%plstr(ipl)%sum_a
+                  end if 
               end if
             end do
           

--- a/src/time_control.f90
+++ b/src/time_control.f90
@@ -220,8 +220,8 @@
           !! zero demand, withdrawal, and unmet for entire allocation object
           wallo(:)%tot = walloz
           !! zero water treatment and use outflow in case they receive water multiple times
-          wtp_om_out(:) = hz
-          wuse_om_out(:) = hz
+          if (allocated(wtp_om_out)) wtp_om_out(:) = hz
+          if (allocated(wuse_om_out)) wuse_om_out(:) = hz
 
           if (time%yrs > pco%nyskip) ndmo(time%mo) = ndmo(time%mo) + 1
 


### PR DESCRIPTION
added if (allocated(x)) to prevent runtime errors in gfortran when water allocation is not being run.