### PR TITLE
Fix continuous grazing applying the wrong operation's parameters on multi-day grazing

### DIFF
--- a/src/allocate_parms.f90
+++ b/src/allocate_parms.f90
@@ -88,6 +88,7 @@
       allocate (doxq(mhru), source = 0.)
       allocate (filterw(mhru), source = 0.)
       allocate (igrz(mhru), source = 0)
+      allocate (grz_dbid(mhru), source = 0)
       allocate (yr_skip(mhru), source = 0)
       allocate (isweep(mhru), source = 0)
       allocate (phusw(mhru), source = 0.)

--- a/src/hru_control.f90
+++ b/src/hru_control.f90
@@ -6,7 +6,7 @@
 
       use hru_module, only : hru, ihru, tillage_switch,                                           &
          tillage_days, ndeat, qdr, phubase, sedyld, surfq, grz_days,                              &
-         yr_skip, latq, sepbtm, igrz, iseptic, i_sep, filterw, sed_con, soln_con, solp_con,       & 
+         yr_skip, latq, sepbtm, igrz, grz_dbid, iseptic, i_sep, filterw, sed_con, soln_con, solp_con,       &
          orgn_con, orgp_con, cnday, percn, tileno3, sedorgn, sedorgp, surqno3, latno3,            &
          surqsolp, sedminpa, sedminps, fertn, fertp, fixn, grazn, grazp, ipl, qp_cms, qtile,      &
          snofall, snomlt, usle, canev, ep_day, es_day, etday, inflpcp, isep, iwgen, ls_overq,     &
@@ -366,6 +366,7 @@
         if (igrz(j) == 1) then
           ndeat(j) = ndeat(j) + 1
           !! if total above ground biomass is available - graze
+          graze = grazeop_db(grz_dbid(j))   !! load THIS hru's grazing params each grazing day
           call pl_graze
           !! check to set if grazing period is over
           if (ndeat(j) == grz_days(j)) then

--- a/src/hru_module.f90
+++ b/src/hru_module.f90
@@ -478,6 +478,7 @@
       !! burn
       integer, dimension (:), allocatable :: grz_days
       integer, dimension (:), allocatable :: igrz
+      integer, dimension (:), allocatable :: grz_dbid   !! per-HRU grazeop_db index for continuous grazing
       integer, dimension (:), allocatable :: ndeat
 
       real, dimension (:), allocatable :: gwsoilq        !rtb gwflow

--- a/src/mgt_sched.f90
+++ b/src/mgt_sched.f90
@@ -5,7 +5,7 @@
       use tillage_data_module
       use basin_module
       use hydrograph_module
-      use hru_module, only : hru, ihru, cn2, phubase, ndeat, igrz, grz_days,    &
+      use hru_module, only : hru, ihru, cn2, phubase, ndeat, igrz, grz_days, grz_dbid,    &
         yr_skip, sol_sumno3, sol_sumsolp, fertnh3, fertno3, fertorgn,  &
         fertorgp, fertsolp, ipl, sweepeff, yr_skip
       use soil_module
@@ -434,7 +434,7 @@
             igrz(j) = 1
             ipl = Max(1, mgt%op2)
             grz_days(j) = Int(mgt%op3)
-            graze = grazeop_db(mgt%op1)
+            grz_dbid(j) = mgt%op1     !! remember this HRU's grazeop_db index for the daily graze loop
 
             if (pco%mgtout == "y") then
               write (2612, *) j, time%yrc, time%mo, time%day_mo, mgt%op_char, "    GRAZE ",     &


### PR DESCRIPTION
Summary

Continuous grazing applies another HRU's grazing parameters on every day after the first. The grazing operation's parameters are stored in a single shared module-level scalar (graze in mgt_operations_module), which is written once when a grazing operation begins (mgt_sched) and then re-read every subsequent day in hru_control. Because graze is one global variable, on each continuation day a grazing HRU reads whatever grazing operation was written most recently — typically a different HRU's — instead of its own.

The per-HRU grazing duration state (igrz, grz_days, ndeat) is already stored in per-HRU arrays; only the grazing parameters were left in a shared scalar. This fix stores the grazing-operation index per HRU as well.

When it manifests

The bug produces wrong results whenever a simulation has both:
- more than one distinct grazing operation defined (graze.ops), and
- grazing that lasts more than one day (grz_days > 1).

A dataset with a single uniform grazing operation is unaffected (the shared scalar always holds the same value), which is likely why it went unnoticed. This is a deterministic error in ordinary single-threaded runs, not a parallelism issue.

Fix

Store the grazeop_db index per HRU (grz_dbid, alongside the existing igrz/grz_days/ndeat arrays) when grazing starts, and load this HRU's parameters from it immediately before each daily pl_graze call.

mgt_sched.f90:   graze = grazeop_db(mgt%op1)   →   grz_dbid(j) = mgt%op1
hru_control.f90:  (before call pl_graze)        →   graze = grazeop_db(grz_dbid(j))

Changed files (4 files, +6/−3):
- hru_module.f90 — declare grz_dbid(:) array
- allocate_parms.f90 — allocate grz_dbid(mhru)
- mgt_sched.f90 — store the grazeop index per HRU at graze start (instead of writing the shared scalar)
- hru_control.f90 — load this HRU's grazing parameters before each daily pl_graze

pl_graze and the decision-table (actions.f90) grazing path are unchanged.

Impact / validation

On a grazing watershed with 5 distinct grazing operations, correcting this shifts biomass on grazed HRUs and cascades downstream. Before/after comparison (single-thread, identical inputs): plant biomass (bm_max) changes by up to ~27%, with corresponding changes in soil evaporation, soil carbon (perc_c), net primary production (npp_c), and the resulting channel/reservoir sediment and nutrient loads. HRUs that don't graze are bit-for-bit unchanged.