### PR TITLE
Fix crashes and numerical robustness that blocked large watersheds (recall, zero-flow FPEs, channel P)

### DIFF
--- a/src/aqu_1d_control.f90
+++ b/src/aqu_1d_control.f90
@@ -137,7 +137,9 @@
         conc_no3 = 0.
       endif
       !! kg = (kg/ha / mm) * mm * ha
-      ob(icmd)%hd(1)%no3 = (conc_no3 * aqu_d(iaq)%flo) * ob(icmd)%area_ha
+      !! Part 12: conc_no3 can be a tiny (but normal) ratio whose product with flo underflows
+      ob(icmd)%hd(1)%no3 = 0.
+      if (abs(conc_no3) >= 1.e-15) ob(icmd)%hd(1)%no3 = (conc_no3 * aqu_d(iaq)%flo) * ob(icmd)%area_ha
       ob(icmd)%hd(1)%no3 = amin1(ob(icmd)%hd(1)%no3, (aqu_d(iaq)%no3_st * ob(icmd)%area_ha))
       aqu_d(iaq)%no3_lat = ob(icmd)%hd(1)%no3 / ob(icmd)%area_ha
       aqu_d(iaq)%no3_st = aqu_d(iaq)%no3_st - aqu_d(iaq)%no3_lat
@@ -151,7 +153,8 @@
       
       !! compute nitrate seepage out of aquifer
       !! kg/ha = (kg/ha / mm) * mm
-      aqu_d(iaq)%no3_seep = conc_no3 * aqu_d(iaq)%seep
+      aqu_d(iaq)%no3_seep = 0.
+      if (abs(conc_no3) >= 1.e-15) aqu_d(iaq)%no3_seep = conc_no3 * aqu_d(iaq)%seep
       aqu_d(iaq)%no3_seep = amin1(aqu_d(iaq)%no3_seep, aqu_d(iaq)%no3_st)
       aqu_d(iaq)%no3_st = aqu_d(iaq)%no3_st - aqu_d(iaq)%no3_seep
       ob(icmd)%hd(2)%no3 = aqu_d(iaq)%no3_seep * ob(icmd)%area_ha

--- a/src/cbn_rsd_transfer.f90
+++ b/src/cbn_rsd_transfer.f90
@@ -44,7 +44,7 @@
       integer :: k = 0      !none          |counter (soil layer)
       real :: decr = 0.     !              |
       integer :: ipl = 0      !              |plant number in plant community
-      real :: idp = 0.      !              |plant number in plant data module
+      integer :: idp = 0    !none          |plant number in plant data module
       real :: nactfr = 0.   !none          |nitrogen active pool fraction. The fraction
                             !              |of organic nitrogen in the active pool.
       real :: clg = 0.      !none          |lignin fraction of the residue

--- a/src/cbn_surfrsd_decomp.f90
+++ b/src/cbn_surfrsd_decomp.f90
@@ -53,8 +53,8 @@
       real :: cprf = 0.     !              |carbon phosphorus ratio factor
       real :: ca = 0.       !              |
       real :: decr = 0.     !              |
-      real :: ipl = 0.      !              |plant number in plant community
-      real :: idp = 0.      !              |plant number in plant data module
+      integer :: ipl = 0    !none          |plant number in plant community
+      integer :: idp = 0    !none          |plant number in plant data module
       real :: cdg = 0.      !none          |soil temperature factor
       real :: sut = 0.      !none          |soil water factor
       real :: nactfr = 0.   !none          |nitrogen active pool fraction. The fraction

--- a/src/ch_temp.f90
+++ b/src/ch_temp.f90
@@ -249,8 +249,8 @@
       yrs_to_start = time%yrs - tmp(ig)%yrs_start   !model year - (tmp start year is model year)
 
       if (jday <= surf_lag .and. yrs_to_start > 1) then
-          t_air_max_av = (sum(tmp(ig)%ts(1:jday,yrs_to_start))+sum(tmp(ig)%ts(jday+365-surf_lag+1:365,yrs_to_start-1)))/surf_lag
-          t_air_min_av = (sum(tmp(ig)%ts2(1:jday,yrs_to_start))+sum(tmp(ig)%ts2(jday+365-surf_lag+1:365,yrs_to_start-1)))/surf_lag
+          t_air_max_av = (sum(tmp(ig)%ts(1:int(jday),yrs_to_start))+sum(tmp(ig)%ts(int(jday+365-surf_lag+1):365,yrs_to_start-1)))/surf_lag
+          t_air_min_av = (sum(tmp(ig)%ts2(1:int(jday),yrs_to_start))+sum(tmp(ig)%ts2(int(jday+365-surf_lag+1):365,yrs_to_start-1)))/surf_lag
       else
           t_air_max_av = sum(tmp(ig)%ts(max(1,int(jday-surf_lag+1)):int(jday),yrs_to_start))/surf_lag
           t_air_min_av = sum(tmp(ig)%ts2(max(1,int(jday-surf_lag+1)):int(jday),yrs_to_start))/surf_lag
@@ -267,8 +267,8 @@
       yrs_to_start = time%yrs - tmp(ig)%yrs_start   !model year - tmp start year is model year
       
       if (jday <= lat_lag .and. yrs_to_start > 1) then
-          t_air_max_av = (sum(tmp(ig)%ts(1:jday,yrs_to_start))+sum(tmp(ig)%ts(jday+365-lat_lag+1:365,yrs_to_start-1)))/lat_lag
-          t_air_min_av = (sum(tmp(ig)%ts2(1:jday,yrs_to_start))+sum(tmp(ig)%ts2(jday+365-lat_lag+1:365,yrs_to_start-1)))/lat_lag
+          t_air_max_av = (sum(tmp(ig)%ts(1:int(jday),yrs_to_start))+sum(tmp(ig)%ts(int(jday+365-lat_lag+1):365,yrs_to_start-1)))/lat_lag
+          t_air_min_av = (sum(tmp(ig)%ts2(1:int(jday),yrs_to_start))+sum(tmp(ig)%ts2(int(jday+365-lat_lag+1):365,yrs_to_start-1)))/lat_lag
       else
           t_air_max_av = sum(tmp(ig)%ts(max(1,int(jday-lat_lag+1)):int(jday),yrs_to_start))/lat_lag
           t_air_min_av = sum(tmp(ig)%ts2(max(1,int(jday-lat_lag+1)):int(jday),yrs_to_start))/lat_lag
@@ -285,8 +285,8 @@
       yrs_to_start = time%yrs - tmp(ig)%yrs_start   !model year -tmp start year is model year
       
       if (jday <= gw_lag .and. yrs_to_start > 1) then
-          t_air_max_av = (sum(tmp(ig)%ts(1:jday,yrs_to_start))+sum(tmp(ig)%ts(jday+365-gw_lag+1:365,yrs_to_start-1)))/gw_lag
-          t_air_min_av = (sum(tmp(ig)%ts2(1:jday,yrs_to_start))+sum(tmp(ig)%ts2(jday+365-gw_lag+1:365,yrs_to_start-1)))/gw_lag
+          t_air_max_av = (sum(tmp(ig)%ts(1:int(jday),yrs_to_start))+sum(tmp(ig)%ts(int(jday+365-gw_lag+1):365,yrs_to_start-1)))/gw_lag
+          t_air_min_av = (sum(tmp(ig)%ts2(1:int(jday),yrs_to_start))+sum(tmp(ig)%ts2(int(jday+365-gw_lag+1):365,yrs_to_start-1)))/gw_lag
       else
           t_air_max_av = sum(tmp(ig)%ts(max(1,int(jday-gw_lag+1)):int(jday),yrs_to_start))/gw_lag
           t_air_min_av = sum(tmp(ig)%ts2(max(1,int(jday-gw_lag+1)):int(jday),yrs_to_start))/gw_lag
@@ -303,8 +303,8 @@
       yrs_to_start = time%yrs - tmp(ig)%yrs_start   !model year - tmp start year is model year
       
       if (jday <= sno_lag .and. yrs_to_start > 1) then
-          t_air_max_av = (sum(tmp(ig)%ts(1:jday,yrs_to_start))+sum(tmp(ig)%ts(jday+365-sno_lag+1:365,yrs_to_start-1)))/sno_lag
-          t_air_min_av = (sum(tmp(ig)%ts2(1:jday,yrs_to_start))+sum(tmp(ig)%ts2(jday+365-sno_lag+1:365,yrs_to_start-1)))/sno_lag
+          t_air_max_av = (sum(tmp(ig)%ts(1:int(jday),yrs_to_start))+sum(tmp(ig)%ts(int(jday+365-sno_lag+1):365,yrs_to_start-1)))/sno_lag
+          t_air_min_av = (sum(tmp(ig)%ts2(1:int(jday),yrs_to_start))+sum(tmp(ig)%ts2(int(jday+365-sno_lag+1):365,yrs_to_start-1)))/sno_lag
       else
           t_air_max_av = sum(tmp(ig)%ts(max(1,int(jday-sno_lag+1)):int(jday),yrs_to_start))/sno_lag
           t_air_min_av = sum(tmp(ig)%ts2(max(1,int(jday-sno_lag+1)):int(jday),yrs_to_start))/sno_lag

--- a/src/ch_watqual4.f90
+++ b/src/ch_watqual4.f90
@@ -122,7 +122,12 @@
       !! interpolate rating curve using peak rate
       call rcurv_interp_flo (ich, flo_rate)
       rchdep = rcurv%dep
-      if (ht1%flo > 0. .and. rchdep > 0.) then
+      !! low-flow floor (1.e-6 m3/day): at negligible flow the concentration = 1000*mass/flo
+      !! below blows up and the in-stream nutrient dynamics become ill-conditioned -- a sub-ULP
+      !! change in flo (from compiler FP reassociation) flips the <1.e-6 solp/sedp threshold and
+      !! produces large, non-physical swings in channel soluble P. Route sub-floor (physically
+      !! zero) flow through the no-flow branch instead. Behavior-neutral for real flows.
+      if (ht1%flo > 1.e-6 .and. rchdep > 0.) then
         disoxin = ht3%dox - rk4_s / (ht1%flo * 1000.)   !m3*1000 l/m3 = liters
         disoxin = max (0., disoxin)
         dispin = ht3%solp + rs2_s / (ht1%flo * 1000.)

--- a/src/hydrograph_module.f90
+++ b/src/hydrograph_module.f90
@@ -1433,25 +1433,38 @@
         real, intent (in) :: const
         type (hyd_output) :: hyd2
         hyd2%temp = hyd1%temp
-        hyd2%flo = const * hyd1%flo 
-        hyd2%sed = const * hyd1%sed !/ 1000.
-        hyd2%orgn = const * hyd1%orgn       
-        hyd2%sedp = const * hyd1%sedp 
-        hyd2%no3 = const * hyd1%no3
-        hyd2%solp = const * hyd1%solp
-        hyd2%chla = const * hyd1%chla
-        hyd2%nh3 = const * hyd1%nh3
-        hyd2%no2 = const * hyd1%no2
-        hyd2%cbod = const * hyd1%cbod
-        hyd2%dox = const * hyd1%dox
-        hyd2%san = const * hyd1%san
-        hyd2%sil = const * hyd1%sil
-        hyd2%cla = const * hyd1%cla
-        hyd2%sag = const * hyd1%sag
-        hyd2%lag = const * hyd1%lag
-        hyd2%grv = const * hyd1%grv
+        !! flush-guarded multiply (Part 12): const*x can be subnormal even when both are
+        !! individually normal real*4 -> underflow FPE trap; fmul returns 0 in that case
+        hyd2%flo = fmul(const, hyd1%flo)
+        hyd2%sed = fmul(const, hyd1%sed) !/ 1000.
+        hyd2%orgn = fmul(const, hyd1%orgn)
+        hyd2%sedp = fmul(const, hyd1%sedp)
+        hyd2%no3 = fmul(const, hyd1%no3)
+        hyd2%solp = fmul(const, hyd1%solp)
+        hyd2%chla = fmul(const, hyd1%chla)
+        hyd2%nh3 = fmul(const, hyd1%nh3)
+        hyd2%no2 = fmul(const, hyd1%no2)
+        hyd2%cbod = fmul(const, hyd1%cbod)
+        hyd2%dox = fmul(const, hyd1%dox)
+        hyd2%san = fmul(const, hyd1%san)
+        hyd2%sil = fmul(const, hyd1%sil)
+        hyd2%cla = fmul(const, hyd1%cla)
+        hyd2%sag = fmul(const, hyd1%sag)
+        hyd2%lag = fmul(const, hyd1%lag)
+        hyd2%grv = fmul(const, hyd1%grv)
         hyd2%temp = hyd1%temp
       end function hydout_mult_const
+
+      !! Part-12 denormal-underflow guard for "* const" mass multiplies: const*x can be a
+      !! subnormal product (< 1.18e-38) that trips the underflow FPE trap. Flush to 0 below 1e-18.
+      elemental real function fmul(const, x)
+        real, intent (in) :: const, x
+        if (abs(x) < 1.e-18 .or. abs(const) < 1.e-18) then
+          fmul = 0.
+        else
+          fmul = const * x
+        end if
+      end function fmul
       
       function hydout_div_const (hyd1,const) result (hyd2)
         type (hyd_output), intent (in) :: hyd1

--- a/src/recall_read.f90
+++ b/src/recall_read.f90
@@ -129,7 +129,7 @@
         
       !! check if the org mineral has already been used in a previous recall object
       do iprev = 1, irec
-        if (recall_db(irec)%org_min%name == recall_db(irec)%org_min%name) then
+        if (recall_db(iprev)%org_min%name == recall_db(irec)%org_min%name) then
           recall_db(irec)%iorg_min = iprev
           exit
         end if

--- a/src/res_control.f90
+++ b/src/res_control.f90
@@ -144,6 +144,10 @@
           alpha_up = Exp(-res_ob(jres)%lag_up)
           alpha_down = Exp(-res_ob(jres)%lag_down)
           !! lag outflow when flows are receding
+          !! flush denormal outflow AND carried prev_flo to 0 before the lag multiplies
+          !! (both x*alpha terms underflow the FPE trap when a value has decayed to ~1e-40)
+          if (abs(ht2%flo) < 1.e-15) ht2%flo = 0.
+          if (abs(res_ob(jres)%prev_flo) < 1.e-15) res_ob(jres)%prev_flo = 0.
           if (res_ob(jres)%prev_flo < ht2%flo) then
             ht2%flo = ht2%flo * alpha_up + res_ob(jres)%prev_flo * (1. - alpha_up)
           else

--- a/src/res_nutrient.f90
+++ b/src/res_nutrient.f90
@@ -26,7 +26,9 @@
       real :: conc_p = 0.        !              |
       real :: conc_soln = 0.     !              |
       real :: conc_solp = 0.     !              |
-      
+      real :: flo_tot = 0.       !              |wbody%flo + ht2%flo, guarded against ~0
+      real :: rto = 0.           !              |ht2%flo / flo_tot, outflow fraction
+
 
       !! if reservoir volume less than 1 m^3, set all nutrient levels to
       !! zero and perform no nutrient calculations
@@ -96,14 +98,25 @@
       wbody%nh3 = max (wbody%nh3, 0.0)
       wbody%no2 = max (wbody%no2, 0.0)
 
-      !! calculate amount of nutrients leaving reservoir
-      ht2%no3 = wbody%no3 * ht2%flo / (wbody%flo + ht2%flo)
-      ht2%orgn = wbody%orgn * ht2%flo / (wbody%flo + ht2%flo)
-      ht2%sedp = wbody%sedp * ht2%flo / (wbody%flo + ht2%flo)
-      ht2%solp = wbody%solp * ht2%flo / (wbody%flo + ht2%flo)
-      ht2%chla = wbody%chla * ht2%flo / (wbody%flo + ht2%flo)
-      ht2%nh3 = wbody%nh3 * ht2%flo / (wbody%flo + ht2%flo)
-      ht2%no2 = wbody%no2 * ht2%flo / (wbody%flo + ht2%flo)
+      !! calculate amount of nutrients leaving reservoir. Compute the outflow FRACTION
+      !! once (bounded ~[0,1]) rather than multiplying wbody%X by raw ht2%flo then dividing:
+      !! guarding each operand at 1.e-30 isn't enough when BOTH clear it but their product
+      !! still underflows (e.g. 1e-29*1e-29). Gate ht2%flo at the 1.e-6 "meaningfully
+      !! nonzero flow" threshold so rto can't land in the denormal range.
+      flo_tot = wbody%flo + ht2%flo
+      if (flo_tot > 1.e-6 .and. abs(ht2%flo) >= 1.e-6) then
+        rto = ht2%flo / flo_tot
+        ht2%no3 = 0.;  if (abs(wbody%no3)  >= 1.e-30 .and. abs(rto) >= 1.e-30) ht2%no3  = wbody%no3  * rto
+        ht2%orgn = 0.; if (abs(wbody%orgn) >= 1.e-30 .and. abs(rto) >= 1.e-30) ht2%orgn = wbody%orgn * rto
+        ht2%sedp = 0.; if (abs(wbody%sedp) >= 1.e-30 .and. abs(rto) >= 1.e-30) ht2%sedp = wbody%sedp * rto
+        ht2%solp = 0.; if (abs(wbody%solp) >= 1.e-30 .and. abs(rto) >= 1.e-30) ht2%solp = wbody%solp * rto
+        ht2%chla = 0.; if (abs(wbody%chla) >= 1.e-30 .and. abs(rto) >= 1.e-30) ht2%chla = wbody%chla * rto
+        ht2%nh3 = 0.;  if (abs(wbody%nh3)  >= 1.e-30 .and. abs(rto) >= 1.e-30) ht2%nh3  = wbody%nh3  * rto
+        ht2%no2 = 0.;  if (abs(wbody%no2)  >= 1.e-30 .and. abs(rto) >= 1.e-30) ht2%no2  = wbody%no2  * rto
+      else
+        ht2%no3 = 0.; ht2%orgn = 0.; ht2%sedp = 0.; ht2%solp = 0.
+        ht2%chla = 0.; ht2%nh3 = 0.; ht2%no2 = 0.
+      end if
       
       !! remove nutrients leaving reservoir
       wbody%no3 = max(0.,wbody%no3 - ht2%no3) !No less than zero, Jaehak 2024

--- a/src/res_sediment.f90
+++ b/src/res_sediment.f90
@@ -24,12 +24,16 @@
         cla_ppm = 1.e-6
       else
 
-        !! compute concentrations
-        sed_ppm = 1000000. * wbody%sed / wbody%flo
+        !! compute concentrations (guard denormal numerators: 1e6*x/flo underflows
+        !! under -ffpe-trap when x has decayed to ~1e-40; physically zero)
+        sed_ppm = 0.
+        if (abs(wbody%sed) >= 1.e-30) sed_ppm = 1000000. * wbody%sed / wbody%flo
         sed_ppm = Max(1.e-6, sed_ppm)
-        sil_ppm = 1000000. * wbody%sil / wbody%flo
+        sil_ppm = 0.
+        if (abs(wbody%sil) >= 1.e-30) sil_ppm = 1000000. * wbody%sil / wbody%flo
         sil_ppm = Max(1.e-6, sil_ppm)
-        cla_ppm = 1000000. * wbody%cla / wbody%flo
+        cla_ppm = 0.
+        if (abs(wbody%cla) >= 1.e-30) cla_ppm = 1000000. * wbody%cla / wbody%flo
         cla_ppm = Max(1.e-6, cla_ppm)
         
         !! compute change in sediment concentration due to settling 
@@ -39,7 +43,9 @@
           !! update wetland sediment after settling
           wbody%sed = sed_ppm * wbody%flo / 1000000.
           !! calculate sediment in the outflow and subtract from wetland
-          ht2%sed = sed_ppm * ht2%flo / 1000000.
+          !! (ht2%flo today's outflow can be ~0/denormal -> guard the multiply)
+          ht2%sed = 0.
+          if (abs(ht2%flo) >= 1.e-30) ht2%sed = sed_ppm * ht2%flo / 1000000.
           wbody%sed = Max(0.,wbody%sed - ht2%sed)
           
           !! assume all sand aggregates and gravel settles

--- a/src/sd_channel_sediment3.f90
+++ b/src/sd_channel_sediment3.f90
@@ -126,7 +126,8 @@
         !! trap efficiency from Dynamic SedNet Component Model Reference Guide: Update 2017
         fp_m2 = 3. * sd_ch(ich)%chw * sd_ch(ich)%chl * 1000.
         exp_co = 0.0001 * fp_m2 / florate_ob
-        trap_eff = sd_ch(ich)%fp_inun_days * (florate_ob / ave_rate) * (1. - exp(-exp_co))
+        !! exp_w guards against underflow when florate_ob is tiny enough that exp_co blows up
+        trap_eff = sd_ch(ich)%fp_inun_days * (florate_ob / ave_rate) * (1. - exp_w(-exp_co))
         trap_eff = Min (1., trap_eff)
         fp_dep%sed = trap_eff * ht1%sed
 

--- a/src/soils_test_adjust.f90
+++ b/src/soils_test_adjust.f90
@@ -11,7 +11,7 @@ subroutine soils_test_adjust(isol, mlyr)
     real :: soil_layer_thickness    !     |thickness of soil layer being processed 
     real :: prev_depth = 0.         !mm   |previous custom depth in millimeters
     real :: sum_bd, sum_cbn, sum_sand, sum_silt, sum_clay !     |temporary sums for weighted averages
-    integer :: tot_soil_depth = 0.  !mm   |total soil depth for the soil being processed
+    integer :: tot_soil_depth = 0   !mm   |total soil depth for the soil being processed
     integer :: test                 !     |soil test index
     integer :: i                    !     |index to sol array
     integer :: j                    !     |index to soildb array, sol_mm_db array
@@ -38,7 +38,7 @@ subroutine soils_test_adjust(isol, mlyr)
                 ! Populate temporary data structure to do weighted averages from.
                 prev_depth = 0
                 do j = 1, soildb(isol)%s%nly
-                    do i = prev_depth + 1, tot_soil_depth
+                    do i = int(prev_depth + 1), tot_soil_depth
                         if (i <= soildb(isol)%ly(j)%z .and. i > prev_depth ) then
                             sol_mm_db(1)%ly(i)%z = i
                             sol_mm_db(1)%ly(i)%bd = soildb(isol)%ly(j)%bd
@@ -89,7 +89,7 @@ subroutine soils_test_adjust(isol, mlyr)
                 if (sol(isol)%phys(i)%d > prev_depth) then
                     ! calculate weighted averages
                     sum_bd = 0.; sum_cbn = 0.; sum_sand = 0.; sum_silt = 0.; sum_clay = 0.
-                    do j = prev_depth + 1, sol(isol)%phys(i)%d
+                    do j = int(prev_depth + 1), int(sol(isol)%phys(i)%d)
                         sum_bd   = sum_bd   + sol_mm_db(1)%ly(j)%bd
                         sum_cbn  = sum_cbn  + sol_mm_db(1)%ly(j)%cbn
                         sum_sand = sum_sand + sol_mm_db(1)%ly(j)%sand

--- a/src/wq_k2m.f90
+++ b/src/wq_k2m.f90
@@ -40,13 +40,19 @@
       real :: wq_k2m
       real :: wq_semianalyt
       
-      h1 = wq_semianalyt (t1, t2, 0., 0., c1, c2)
-      h2 = wq_semianalyt (t1, t2, 0., tk, c1, c2)
-      help = exp_w(-t2 / t1)
-         
-      tm = (h2 - c1 * help) / (t1 * (1. - help)) - c2 / t1
-      h3 = wq_semianalyt (t1, t2, tm, 0., c1, c2)
-      wq_k2m = tm
+    !! t1 (tres) too small (or zero) relative to t2 (tdel) -- the divisions by t1
+    !! below would blow up. Same degenerate case wq_semianalyt guards against.
+      if (t1 <= t2) then
+        wq_k2m = 0.
+      else
+        h1 = wq_semianalyt (t1, t2, 0., 0., c1, c2)
+        h2 = wq_semianalyt (t1, t2, 0., tk, c1, c2)
+        help = exp_w(-t2 / t1)
+
+        tm = (h2 - c1 * help) / (t1 * (1. - help)) - c2 / t1
+        h3 = wq_semianalyt (t1, t2, tm, 0., c1, c2)
+        wq_k2m = tm
+      end if
 
       return
       end function wq_k2m

--- a/src/wq_semianalyt.f90
+++ b/src/wq_semianalyt.f90
@@ -42,19 +42,20 @@
       real :: yy = 0.
       real :: wq_semianalyt
 
-      help1 = 1. / tres - prock
-      help2 = exp_w(-tdel * help1)
-      help3 = cint / tres + term_m
-      help4 = help3 / help1
-      term1 = cprev * help2
-      term2 = help4 * (1. - help2)
-      yy = term1 + term2
-      wq_semianalyt = term1 + term2
-      
-    !! if time of residence in reach is less than or eq to timestep don't do this. MJW 2023
-      !if (tres <= tdel) then
-      !    wq_semianalyt = cint  
-      !end if
+    !! if time of residence in reach is less than or eq to timestep, tres is too
+    !! small (or zero) for the analytic solution -- 1./tres divides by zero. MJW 2023
+      if (tres <= tdel) then
+        wq_semianalyt = cint
+      else
+        help1 = 1. / tres - prock
+        help2 = exp_w(-tdel * help1)
+        help3 = cint / tres + term_m
+        help4 = help3 / help1
+        term1 = cprev * help2
+        term2 = help4 * (1. - help2)
+        yy = term1 + term2
+        wq_semianalyt = term1 + term2
+      end if
 
       return
       end function wq_semianalyt


### PR DESCRIPTION
Summary:

Overview

With the FPE trap enabled (the shipped build config), SWAT+ could not run a large real watershed to completion — it crashed during the first day of simulation, then hit a series of zero-flow floating-point exceptions, and exhibited a large non-physical sensitivity in channel phosphorus under optimization. This PR fixes all three, validated on the full Raccoon Creek watershed (7949 HRUs, 1370 channels, 49 reservoirs, 33 aquifers, 33 recall objects), which now completes a 10-year run cleanly with the trap on.

Each fix is a genuine defect, independent of dataset size, and behavior-neutral for normal conditions.

Changes

1. Recall reader crash (recall_read.f90) — fixes a day-1 segfault
The "already used in a previous recall object" dedup loop compared an object to itself (recall_db(irec)%…name == recall_db(irec)%…name), which is always true. Every recall object after the first was wrongly flagged a duplicate and skipped reading its own data, leaving recall%hd unallocated → segfault when routing reads it on day 1. Only manifests with 2+ recall objects. Fixed to compare against recall_db(iprev) as intended (1-line change).

2. Zero-flow denormal underflow guards (8 files: wq_semianalyt, wq_k2m, ch_watqual4, hydrograph_module, res_nutrient, res_sediment, res_control, aqu_1d_control, sd_channel_sediment3) — fixes FPE crashes under -ffpe-trap=underflow
Reaches, reservoirs, and aquifers with ~zero flow produce subnormal intermediate values (e.g. 1./tres at zero residence time, conc × tiny_flow, a*b+c mass multiplies) that trip the underflow trap. Each guard flushes the physically-zero degenerate case to 0 — behavior-neutral for normal flows. Not needed if the trap is disabled, but correct to have.

3. Channel soluble-P numerical robustness (ch_watqual4.f90) — fixes an ill-conditioned computation
The in-stream WQ routine computes concentration as 1000 × mass / flow, which blows up as flow → 0. That huge, ill-conditioned concentration feeds a nonlinear P reaction chain guarded by a hard < 1.e-6 threshold, so a sub-ULP change in flow (e.g. from compiler FP reassociation) flips the threshold and produces large, non-physical swings in channel soluble P — deterministic per build, but differing wildly between -O0 and -O3 builds of identical source. A 1.e-6 m³/day low-flow floor routes physically-negligible flow through the existing no-flow branch, removing the sensitivity with no effect on real flows.

Validation

- Full Raccoon Creek watershed, 10-year run, cswat=1, FPE trap enabled → completes cleanly (previously crashed/FPE'd at each site in turn).
- The channel-P fix collapses a 170× -O0-vs--O3 divergence in solp_out to negligible, leaving all other outputs unchanged.