### PR TITLE
Fix CENTURY (cswat=1) net mineralization dumping the whole nitrate pool into ammonium

### DIFF
--- a/src/cbn_zhang2.f90
+++ b/src/cbn_zhang2.f90
@@ -114,6 +114,12 @@
        integer :: kk = 0         !                     | soil layer index if k > 1 else kk = 2
        real :: min_n_ppm = 0     !                     |
        real :: min_n = 0         !                     |
+       !! no initializers on the three below: an initializer implies SAVE, which is a
+       !! shared-state hazard under threading (see tmp/threading_playbook.md Part 20).
+       !! all three are assigned before first read in the immobilization block.
+       real :: imm_dmd           !kg N/ha              |immobilization demand for the layer-day
+       real :: imm_nh4           !kg N/ha              |immobilization actually drawn from nh4
+       real :: imm_no3           !kg N/ha              |immobilization actually drawn from no3
        integer :: cf_lyr         !                     |which layer of coefs to use in carbon_coef.cbn
        real :: soil_lyr_thickness !mm
        real :: sol_mass = 0.     !                     |
@@ -722,11 +728,27 @@
               rnmn = sum - trnn
               
         !     update
+              !! rnmn > 0 -> net mineralization: organic n is released to the mineral
+              !!             pool as ammonium (ammonification). no3 is not touched.
+              !! rnmn < 0 -> net immobilization: microbes assimilate ammonium
+              !!             preferentially, drawing no3 only after nh4 is exhausted
+              !!             (century/daycent convention), clipped at what is available.
+              !! NOTE on ordering: hru_control calls cbn_zhang2 BEFORE nut_nitvol, so
+              !! immobilization gets first claim on nh4 each day and nitrification only
+              !! sees what is left. That is a deliberate ordering choice, not a law.
+              !! The clips below should be unreachable - reduc (above) already limits
+              !! demand to wmin = no3 + nh4 + sum - but trnn is recomputed after reduc
+              !! is applied, so the bound is approximate. Kept as a safety net.
               if (rnmn > 0.) then
-                min_n = Max(0., soil1(j)%mn(k)%no3 - rnmn)
-                soil1(j)%mn(k)%nh4 = soil1(j)%mn(k)%nh4 + min_n
-                soil1(j)%mn(k)%no3 = soil1(j)%mn(k)%no3 - min_n
-                ! print*, "2. in cbn_zhang2", k, soil1(j)%mn(k)%no3, min_n
+                soil1(j)%mn(k)%nh4 = soil1(j)%mn(k)%nh4 + rnmn
+              else
+                imm_dmd = -rnmn
+                imm_nh4 = Min(imm_dmd, soil1(j)%mn(k)%nh4)
+                soil1(j)%mn(k)%nh4 = soil1(j)%mn(k)%nh4 - imm_nh4
+                imm_no3 = Min(imm_dmd - imm_nh4, soil1(j)%mn(k)%no3)
+                soil1(j)%mn(k)%no3 = soil1(j)%mn(k)%no3 - imm_no3
+                !! rnmn reduced to the immobilization actually satisfied
+                rnmn = -(imm_nh4 + imm_no3)
               end if
               
 	          ! calculate p flows

--- a/src/res_nutrient.f90
+++ b/src/res_nutrient.f90
@@ -37,6 +37,24 @@
         return
       end if
 
+      !! snap negligible nutrient masses to zero before any arithmetic below.
+      !! the settling block multiplies each of these pools by a factor < 1 every day
+      !! and NOTHING in the hru -> reservoir path replenishes no2 (and nh3/no2 only
+      !! rarely), so they decay geometrically with no floor. Left alone they inevitably
+      !! reach the denormal range (< 1.18e-38 for real4), and the next multiply or the
+      !! conc_* divides below then trip -ffpe-trap=underflow, which this project builds
+      !! with in EVERY configuration (see CMakeLists fdialect). Observed: a reservoir
+      !! holding 75599 m^3, no3 = 3052 kg and orgn = 1347 kg died on no2 = 1.208e-38.
+      !! 1.e-30 kg is physically indistinguishable from zero and matches the threshold
+      !! already used in the outflow block further down.
+      if (wbody%orgn < 1.e-30) wbody%orgn = 0.
+      if (wbody%sedp < 1.e-30) wbody%sedp = 0.
+      if (wbody%solp < 1.e-30) wbody%solp = 0.
+      if (wbody%no3  < 1.e-30) wbody%no3  = 0.
+      if (wbody%nh3  < 1.e-30) wbody%nh3  = 0.
+      if (wbody%no2  < 1.e-30) wbody%no2  = 0.
+      if (wbody%chla < 1.e-30) wbody%chla = 0.
+
       !! if reservoir volume greater than 1 m^3, perform nutrient calculations
       if (time%mo >= wbody_prm%nut%ires1 .and. time%mo <= wbody_prm%nut%ires2) then
         nsetlr = wbody_prm%nut%nsetlr1


### PR DESCRIPTION
The body covers, in order:

- Summary — what's wrong, that it's not fertilizer-specific, the two commits, 44/4 across 2 files
- Defect 1 — the no3_new = min(no3, rnmn) derivation, the three-orders-of-magnitude scale mismatch, why it looked intermittent, and the nut_nitvol volatilization amplifier
- Defect 2 — the missing else, and the NH4-first choice with its ordering consequence
- Defect 3 — the res_nutrient underflow, with the faulting operands and the point that it's latent, not a regression
- Validation — completion on all three datasets, the Clayton before/after (0.14/139.19 → 139.30/0.52), and watershed-scale deltas for both Raccoon sets
- Reviewer notes — five numbered items
- Provenance — 879b016, and why the predecessor was milder

Two things I deliberately made prominent rather than burying:

Reviewer note 1 leads with "this is calibration-breaking." Yields up 39-80% is the kind of number that gets a PR reverted if a reviewer meets it as a surprise in the diff. Stating it as a known, expected consequence — and explicitly asking for a modeller's review rather than just a code review — is more likely to get it merged than downplaying it.

Defect 3 is framed as latent-but-surfaced. I claim that, so the PR needs to carry the evidence: NO2 is a one-way decay with nothing replenishing it, the trap is on in every build config, and the guard is bit-identical where it doesn't fire. All three are stated so a reviewer can check the reasoning rather than take it on faith.