### PR TITLE
Fix decision-table irrigation silently stopping after the first few year

### DIFF
--- a/src/conditions.f90
+++ b/src/conditions.f90
@@ -210,8 +210,12 @@
           end do
           !plant not in community of ipl = 0
           if (ipl == 0) then
-            d_tbl%act_hit(ialt) = "n"
-          else 
+            do ialt = 1, d_tbl%alts
+              if (d_tbl%alt(ic,ialt) == "=") then   !alternative requires the plant - it can't be growing
+                d_tbl%act_hit(ialt) = "n"
+              end if
+            end do
+          else
             !if plant is in the community - check to see if it is growing
             do ialt = 1, d_tbl%alts
               if (d_tbl%alt(ic,ialt) == "=") then    !determine if growing (y) or not (n)

--- a/src/time_control.f90
+++ b/src/time_control.f90
@@ -355,7 +355,7 @@
           iob = sp_ob1%hru + j - 1
           if (ob(iob)%lat >= 0) then
             ! zero yearly irrigation for dtbl conditioning jga6-25
-            !hru(j)%irr_yr = 0.
+            hru(j)%irr_yr = 0.
             
             phubase(j) = 0.
             yr_skip(j) = 0


### PR DESCRIPTION
SUMMARY
-------
Auto-irrigation driven by a lum.dtl decision table stops firing partway
through a run and never resumes. On workdata/CA-Stanislaus_EoceneDC2
(36 years, single HRU) the model applied irrigation in only 4 of 36 years:
33 events instead of 692.

Two independent defects are fixed here. A third, a data-file problem in the
CSIP-generated lum.dtl, is documented below but NOT addressed.


1. hru%irr_yr WAS NEVER RESET AT END OF YEAR   (commit 984a1ab)
---------------------------------------------------------------
The irr_year decision-table condition is meant to cap irrigation per
CALENDAR YEAR. The line that zeroes the accumulator at year end was
commented out in 6d0c8e0 ("Updated on the outputs", 2025-10-29):

    if (ob(iob)%lat >= 0) then
      ! zero yearly irrigation for dtbl conditioning jga6-25
    -   !hru(j)%irr_yr = 0.
    +   hru(j)%irr_yr = 0.

Without it, irr_year compares against a RUN-CUMULATIVE total. Once that
total passes the limit, the condition latches off permanently and irrigation
stops for the remainder of the simulation.

The commit immediately before it, c83a2f3, had just FIXED this same line's
HRU index, so the reset was functional for exactly one commit before being
disabled.

The observed pattern follows arithmetically. Each event applies 32.3 mm
(the table's CONST of 38 mm x sprinkler_med efficiency 0.85):

    Years        irr_year limit (mm)   Cumulative        Events
    ---------    -------------------   ---------------   ----------------
    2000                         762   ->  549.1         17
    2001                         762   ->  775.2          7, then blocked
    2002-2019                    762       775.2 frozen   0
    2020                         777   ->  807.5          1
    2021                         780       807.5          0
    2022                        1063   -> 1065.9          8, then blocked
    2023-2035                <= 1063      1065.9 frozen   0

The only years that irrigate are those whose limit happens to sit just above
the frozen total, which is why the symptom looked arbitrary.


2. UNINITIALIZED ALTERNATIVE INDEX IN plant_name_gro   (commit 41b2b9d)
-----------------------------------------------------------------------
When the named plant is not in the HRU's plant community, conditions.f90
assigned d_tbl%act_hit(ialt) with ialt never set:

    if (ipl == 0) then
    -   d_tbl%act_hit(ialt) = "n"
    +   do ialt = 1, d_tbl%alts
    +     if (d_tbl%alt(ic,ialt) == "=") then
    +       d_tbl%act_hit(ialt) = "n"
    +     end if
    +   end do
    else

GNU builds in this repo always compile with -finit-local-zero -fcheck=all
(CMakeLists.txt ~line 54), so ialt is 0 and the run ABORTS ON THE FIRST
SIMULATED DAY. Builds without bounds checking, including the macOS ifx
binary shipped in the dataset folder, silently write out of bounds instead,
which is why this presented as wrong results rather than a crash.

The new loop mirrors the branch already taken when the plant IS in the
community.


VALIDATION
----------
Four runs of CA-Stanislaus_EoceneDC2, isolating each change
(gfortran Release, cswat=1):

    Run   irr_yr reset     crash fix   lum.dtl        Result
    ---   --------------   ---------   ------------   ------------------------
    A     commented out    no          as generated   33 events (17/7/1/8)
    B     commented out    no          as generated   ABORTS day 1 of 2000
    C     RESTORED         yes         as generated   692 events, every year
    D     commented out    yes         corrected      33 events (17/7/1/8)

Run D is the control: with the crash fix and a corrected data file but the
reset still commented out, the result is identical to the original symptom.
This pins the behaviour change on the irr_yr reset alone.


IMPACT ON RESULTS  -- READ THIS
-------------------------------
This changes model output for any dataset whose lum.dtl uses an irr_year
condition. On the test dataset, total applied irrigation goes from 1,066 mm
to 22,352 mm over 36 years. Anything calibrated against the broken behaviour
will need to be revisited.

Datasets that do not use irr_year are unaffected by commit 984a1ab.
Commit 41b2b9d only alters behaviour when a plant_name_gro condition names a
plant absent from the HRU's community, which was previously undefined
behaviour in every case.

KNOWN GAPS / FOLLOW-UPS  (not in this PR)
-----------------------------------------
* Southern hemisphere still broken. The restored reset sits inside the
  "if (ob(iob)%lat >= 0)" branch. The southern-hemisphere path, which resets
  near day 181, never zeroes irr_yr at all.

* lum.dtl column defect. The CSIP generator writes plant names into the
  lim_const field, which is declared real. conditions.f90 reads the name from
  lim_var for plant_name_gro, and reads lim_const as a NUMERIC PLANT INDEX
  for plant_gro. 66 of 378 condition rows in the test file fail to parse.

* dtbl_lum_read.f90 swallows read errors. The list-directed read fails with
  iostat = 5010, but the reader only tests "eof < 0". The error is discarded,
  leaving lim_var/lim_const at defaults and, worse, the row's alternative
  flags NEVER ASSIGNED, so they retain uninitialized heap content. Adding an
  "iostat > 0" check would have caught all 66 rows at load time. Note that
  doing so will make the affected datasets fail loudly until regenerated.


RULED OUT
---------
* "Crops never started growing due to insufficient moisture" - no. All 52
  plant, 112 harvest and 51 kill operations fire on schedule in every year,
  including zero-irrigation years.

* "Plant stress not reset when a new crop is planted" - no.
  hru_control.f90:229-237 re-zeroes all six stress terms to 1.0 for every
  plant at the top of every day.

Related behaviour that is correct and intentional: when no plant is growing,
w_stress evaluates to 1.0, so a "w_stress < 0.8" condition is false and
irrigation cannot trigger before emergence.

TEST PLAN
---------
    [x] Builds clean with gfortran Release (-fcheck=all -finit-local-zero)
    [x] CA-Stanislaus_EoceneDC2 runs to completion (previously aborted day 1)
    [x] Irrigation fires in all 36 years; annual depths track the per-year
        irr_year limits
    [x] Control run confirms irr_yr reset is the sole cause of the year-count
        change
    [ ] Regression check against a dataset with no irr_year condition
        (expected: bit-identical)